### PR TITLE
fix(tools_v33): fix two broken MCP tool calls in forget and run_maint…

### DIFF
--- a/src/superlocalmemory/mcp/tools_v33.py
+++ b/src/superlocalmemory/mcp/tools_v33.py
@@ -81,8 +81,9 @@ def register_v33_tools(server, get_engine: Callable) -> None:
                 facts = engine._db.get_all_facts(pid)
                 zones = {"active": 0, "warm": 0, "cold": 0, "archive": 0, "forgotten": 0}
                 for f in facts:
-                    r = ebbinghaus.compute_retention(f.access_count or 0, f.importance or 0.5, 0, 0.0)
-                    zone = ebbinghaus.classify_zone(r)
+                    strength = ebbinghaus.memory_strength(f.access_count or 0, f.importance or 0.5, 0, 0.0)
+                    r = ebbinghaus.retention(hours_since_access = 0.0, strength=strength)
+                    zone = ebbinghaus.lifecycle_zone(r)
                     zones[zone] = zones.get(zone, 0) + 1
                 result = {"total": len(facts), "transitions": 0, "dry_run_zones": zones}
             else:
@@ -399,9 +400,9 @@ def register_v33_tools(server, get_engine: Callable) -> None:
             # 3. Behavioral pattern mining
             try:
                 from superlocalmemory.learning.consolidation_worker import ConsolidationWorker
-                cw = ConsolidationWorker(engine._db, engine._config)
-                patterns = cw._generate_patterns(pid)
-                results["behavioral"] = {"patterns_mined": len(patterns)}
+                cw = ConsolidationWorker(MEMORY_DIR / "memory.db", MEMORY_DIR / "learning.db")
+                count = cw._generate_patterns(pid, False)
+                results["behavioral"] = {"patterns_mined": count}
             except Exception as exc:
                 results["behavioral"] = {"error": str(exc)}
 

--- a/src/superlocalmemory/mcp/tools_v33.py
+++ b/src/superlocalmemory/mcp/tools_v33.py
@@ -403,7 +403,7 @@ def register_v33_tools(server, get_engine: Callable) -> None:
             # 3. Behavioral pattern mining
             try:
                 from superlocalmemory.learning.consolidation_worker import ConsolidationWorker
-                cw = ConsolidationWorker(MEMORY_DIR / "memory.db", MEMORY_DIR / "learning.db")
+                cw = ConsolidationWorker(engine._db.db_path, engine._db.db_path.parent / "learning.db",)
                 count = cw._generate_patterns(pid, False)
                 results["behavioral"] = {"patterns_mined": count}
             except Exception as exc:

--- a/src/superlocalmemory/mcp/tools_v33.py
+++ b/src/superlocalmemory/mcp/tools_v33.py
@@ -76,15 +76,19 @@ def register_v33_tools(server, get_engine: Callable) -> None:
             )
 
             if dry_run:
-                # Dry run: compute retention stats without applying changes
-                facts = engine._db.get_all_facts(pid)
+                rows = engine._db.execute(
+                    "SELECT lifecycle_zone, COUNT(*) as cnt "
+                    "FROM fact_retention WHERE profile_id = ? "
+                    "GROUP BY lifecycle_zone",
+                    (pid,),
+                )
                 zones = {"active": 0, "warm": 0, "cold": 0, "archive": 0, "forgotten": 0}
-                for f in facts:
-                    strength = ebbinghaus.memory_strength(f.access_count or 0, f.importance or 0.5, 0, 0.0)
-                    r = ebbinghaus.retention(hours_since_access = 0.0, strength=strength)
-                    zone = ebbinghaus.lifecycle_zone(r)
-                    zones[zone] = zones.get(zone, 0) + 1
-                result = {"total": len(facts), "transitions": 0, "dry_run_zones": zones}
+                total = 0
+                for row in rows:
+                    r = dict(row)
+                    zones[r["lifecycle_zone"]] = int(r["cnt"])
+                    total += int(r["cnt"])
+                result = {"total": total, "transitions": 0, "dry_run_zones": zones}
             else:
                 result = scheduler.run_decay_cycle(pid, force=True)
 

--- a/src/superlocalmemory/mcp/tools_v33.py
+++ b/src/superlocalmemory/mcp/tools_v33.py
@@ -77,7 +77,6 @@ def register_v33_tools(server, get_engine: Callable) -> None:
 
             if dry_run:
                 # Dry run: compute retention stats without applying changes
-                from superlocalmemory.math.ebbinghaus import EbbinghausCurve as _EC
                 facts = engine._db.get_all_facts(pid)
                 zones = {"active": 0, "warm": 0, "cold": 0, "archive": 0, "forgotten": 0}
                 for f in facts:

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -175,7 +175,7 @@ class TestForgetTool:
         return srv._tools["forget"], engine
 
     def test_forget_returns_success_with_stats(self):
-        """forget dry_run=True returns zone counts from fact_retention."""
+        """forget dry_run=False returns zone counts from fact_retention."""
         tool, engine = self._get_tool()
 
         mock_result = {
@@ -203,7 +203,7 @@ class TestForgetTool:
         assert result["dry_run"] is False
 
     def test_forget_dry_run_returns_zone_distribution(self):
-        """forget returns zone counts and averages."""
+        """forget dry_run=True returns zone counts from fact_retention."""
         tool, engine = self._get_tool()
 
         mock_rows = [

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -624,7 +624,6 @@ class TestRunMaintenanceTool:
         tool, engine = self._get_tool()
 
         with (
-            patch("superlocalmemory.learning.consolidation_worker.ConsolidationWorker") as MockCW,
             patch(
                 "superlocalmemory.core.maintenance.run_maintenance",
                 return_value={"updated": 0},
@@ -632,7 +631,7 @@ class TestRunMaintenanceTool:
             patch(
                 "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
             ) as MockSched,
-            patch("superlocalmemory.math.ebbinghaus.EbbinghausCurve"),
+            patch("superlocalmemory.learning.consolidation_worker.ConsolidationWorker", autospec=True) as MockCW,
         ):
             MockSched.return_value.run_decay_cycle.return_value = {
                 "total": 0,
@@ -648,7 +647,6 @@ class TestRunMaintenanceTool:
 
         assert result["success"] is True
         assert result["behavioral"]["patterns_mined"] == 7
-        init_args = MockCW.call_args[0]
         expected_memory = engine._db.db_path
         expected_learning = engine._db.db_path.parent / "learning.db"
         MockCW.assert_called_once_with(expected_memory, expected_learning)

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -191,7 +191,7 @@ class TestForgetTool:
         assert result["total"] == 100
         assert result["transitions"] == 8
         assert result["dry_run"] is False
-    
+
     def test_forget_dry_run_returns_zone_distribution(self):
         """forget returns zone counts and averages."""
         tool, engine = self._get_tool()

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -191,6 +191,27 @@ class TestForgetTool:
         assert result["total"] == 100
         assert result["transitions"] == 8
         assert result["dry_run"] is False
+    
+    def test_forget_dry_run_returns_zone_distribution(self):
+        """forget returns zone counts and averages."""
+        tool, engine = self._get_tool()
+
+        mock_rows = [
+           {"lifecycle_zone": "active", "cnt": 50},
+           {"lifecycle_zone": "warm", "cnt": 20},
+           {"lifecycle_zone": "cold", "cnt": 10},
+           {"lifecycle_zone": "archive", "cnt": 5},
+           {"lifecycle_zone": "forgotten", "cnt": 3},
+        ]
+        engine._db.execute.return_value = mock_rows
+
+        result = _run(tool())
+
+        assert result["success"] is True
+        assert result["total"] == 88
+        assert result["dry_run_zones"]["active"] == 50
+        assert result["dry_run_zones"]["warm"] == 20
+        assert result["dry_run_zones"]["cold"] == 10
 
     def test_forget_with_profile(self):
         """forget tool uses provided profile_id."""

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -570,3 +570,46 @@ class TestGetRetentionStatsTool:
         # Verify query used custom profile
         call_args = engine._db.execute.call_args
         assert call_args[0][1] == ("custom",)
+
+# ---------------------------------------------------------------------------
+# Maintenance Tools tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunMaintenanceTool:
+    """Tests for the run_maintenance MCP tool."""
+
+    def _get_tool(self):
+        from superlocalmemory.mcp.tools_v33 import register_v33_tools
+        srv = _MockServer()
+        engine = _make_mock_engine()
+        get_engine = MagicMock(return_value=engine)
+        register_v33_tools(srv, get_engine)
+        return srv._tools["run_maintenance"], engine
+
+    def test_behavioral_patterns_mined(self):
+        """run_maintenance behavioral section uses correct ConsolidationWorker args."""
+        tool, engine = self._get_tool()
+
+        with patch(
+            "superlocalmemory.learning.consolidation_worker.ConsolidationWorker"
+        ) as MockCW, patch(
+            "superlocalmemory.core.maintenance.run_maintenance",
+            return_value={"updated": 0},
+        ), patch(
+            "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
+        ) as MockSched, patch(
+            "superlocalmemory.math.ebbinghaus.EbbinghausCurve"
+        ):
+            MockSched.return_value.run_decay_cycle.return_value = {
+                "total": 0, "active": 0, "warm": 0,
+                "cold": 0, "archive": 0, "forgotten": 0, "transitions": 0,
+            }
+            MockCW.return_value._generate_patterns.return_value = 7
+            result = _run(tool())
+
+        assert result["success"] is True
+        assert result["behavioral"]["patterns_mined"] == 7
+        init_args = MockCW.call_args[0]
+        assert init_args[0] == engine._db.db_path
+        assert init_args[1] == engine._db.db_path.parent / "learning.db"

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -175,7 +175,7 @@ class TestForgetTool:
         return srv._tools["forget"], engine
 
     def test_forget_returns_success_with_stats(self):
-        """forget tool (dry_run=False) returns decay cycle stats on success."""
+        """forget dry_run=True returns zone counts from fact_retention."""
         tool, engine = self._get_tool()
 
         mock_result = {
@@ -651,3 +651,4 @@ class TestRunMaintenanceTool:
         init_args = MockCW.call_args[0]
         assert init_args[0] == engine._db.db_path
         assert init_args[1] == engine._db.db_path.parent / "learning.db"
+        MockCW.return_value._generate_patterns.assert_called_once_with(engine.profile_id, False)

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -42,6 +42,7 @@ class _MockServer:
         def decorator(fn):
             self._tools[fn.__name__] = fn
             return fn
+
         return decorator
 
 
@@ -92,8 +93,7 @@ class TestV33ToolRegistration:
         register_v33_tools(srv, get_engine)
 
         assert len(srv._tools) == 7, (
-            f"Expected 7 V3.3 tools, got {len(srv._tools)}: "
-            f"{sorted(srv._tools.keys())}"
+            f"Expected 7 V3.3 tools, got {len(srv._tools)}: {sorted(srv._tools.keys())}"
         )
 
     def test_expected_tool_names(self):
@@ -104,8 +104,12 @@ class TestV33ToolRegistration:
         register_v33_tools(srv, MagicMock())
 
         expected = {
-            "forget", "quantize", "consolidate_cognitive",
-            "get_soft_prompts", "reap_processes", "get_retention_stats",
+            "forget",
+            "quantize",
+            "consolidate_cognitive",
+            "get_soft_prompts",
+            "reap_processes",
+            "get_retention_stats",
             "run_maintenance",
         }
         assert set(srv._tools.keys()) == expected
@@ -163,6 +167,7 @@ class TestForgetTool:
 
     def _get_tool(self):
         from superlocalmemory.mcp.tools_v33 import register_v33_tools
+
         srv = _MockServer()
         engine = _make_mock_engine()
         get_engine = MagicMock(return_value=engine)
@@ -174,15 +179,20 @@ class TestForgetTool:
         tool, engine = self._get_tool()
 
         mock_result = {
-            "total": 100, "active": 50, "warm": 20,
-            "cold": 15, "archive": 10, "forgotten": 5,
+            "total": 100,
+            "active": 50,
+            "warm": 20,
+            "cold": 15,
+            "archive": 10,
+            "forgotten": 5,
             "transitions": 8,
         }
 
-        with patch(
-            "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
-        ) as MockSched, patch(
-            "superlocalmemory.math.ebbinghaus.EbbinghausCurve"
+        with (
+            patch(
+                "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
+            ) as MockSched,
+            patch("superlocalmemory.math.ebbinghaus.EbbinghausCurve"),
         ):
             MockSched.return_value.run_decay_cycle.return_value = mock_result
             result = _run(tool(dry_run=False))
@@ -197,11 +207,11 @@ class TestForgetTool:
         tool, engine = self._get_tool()
 
         mock_rows = [
-           {"lifecycle_zone": "active", "cnt": 50},
-           {"lifecycle_zone": "warm", "cnt": 20},
-           {"lifecycle_zone": "cold", "cnt": 10},
-           {"lifecycle_zone": "archive", "cnt": 5},
-           {"lifecycle_zone": "forgotten", "cnt": 3},
+            {"lifecycle_zone": "active", "cnt": 50},
+            {"lifecycle_zone": "warm", "cnt": 20},
+            {"lifecycle_zone": "cold", "cnt": 10},
+            {"lifecycle_zone": "archive", "cnt": 5},
+            {"lifecycle_zone": "forgotten", "cnt": 3},
         ]
         engine._db.execute.return_value = mock_rows
 
@@ -217,21 +227,29 @@ class TestForgetTool:
         """forget tool uses provided profile_id."""
         tool, engine = self._get_tool()
 
-        mock_result = {"total": 0, "active": 0, "warm": 0,
-                       "cold": 0, "archive": 0, "forgotten": 0,
-                       "transitions": 0}
+        mock_result = {
+            "total": 0,
+            "active": 0,
+            "warm": 0,
+            "cold": 0,
+            "archive": 0,
+            "forgotten": 0,
+            "transitions": 0,
+        }
 
-        with patch(
-            "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
-        ) as MockSched, patch(
-            "superlocalmemory.math.ebbinghaus.EbbinghausCurve"
+        with (
+            patch(
+                "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
+            ) as MockSched,
+            patch("superlocalmemory.math.ebbinghaus.EbbinghausCurve"),
         ):
             MockSched.return_value.run_decay_cycle.return_value = mock_result
             result = _run(tool(profile_id="custom-profile", dry_run=False))
 
         assert result["success"] is True
         MockSched.return_value.run_decay_cycle.assert_called_once_with(
-            "custom-profile", force=True,
+            "custom-profile",
+            force=True,
         )
 
     def test_forget_handles_error(self):
@@ -258,6 +276,7 @@ class TestQuantizeTool:
 
     def _get_tool(self):
         from superlocalmemory.mcp.tools_v33 import register_v33_tools
+
         srv = _MockServer()
         engine = _make_mock_engine()
         get_engine = MagicMock(return_value=engine)
@@ -269,20 +288,20 @@ class TestQuantizeTool:
         tool, engine = self._get_tool()
 
         mock_result = {
-            "total": 50, "downgrades": 10, "upgrades": 3,
-            "skipped": 35, "deleted": 2, "errors": 0,
+            "total": 50,
+            "downgrades": 10,
+            "upgrades": 3,
+            "skipped": 35,
+            "deleted": 2,
+            "errors": 0,
         }
 
-        with patch(
-            "superlocalmemory.dynamics.eap_scheduler.EAPScheduler"
-        ) as MockEAP, patch(
-            "superlocalmemory.math.ebbinghaus.EbbinghausCurve"
-        ), patch(
-            "superlocalmemory.storage.quantized_store.QuantizedEmbeddingStore"
-        ), patch(
-            "superlocalmemory.math.polar_quant.PolarQuantEncoder"
-        ), patch(
-            "superlocalmemory.math.qjl.QJLEncoder"
+        with (
+            patch("superlocalmemory.dynamics.eap_scheduler.EAPScheduler") as MockEAP,
+            patch("superlocalmemory.math.ebbinghaus.EbbinghausCurve"),
+            patch("superlocalmemory.storage.quantized_store.QuantizedEmbeddingStore"),
+            patch("superlocalmemory.math.polar_quant.PolarQuantEncoder"),
+            patch("superlocalmemory.math.qjl.QJLEncoder"),
         ):
             MockEAP.return_value.run_eap_cycle.return_value = mock_result
             result = _run(tool(dry_run=False))
@@ -314,6 +333,7 @@ class TestQuantizeTool:
 @dataclass
 class _MockCCQResult:
     """Minimal CCQ pipeline result for testing."""
+
     clusters_processed: int = 3
     blocks_created: int = 2
     facts_archived: int = 15
@@ -329,6 +349,7 @@ class TestConsolidateCognitiveTool:
 
     def _get_tool(self):
         from superlocalmemory.mcp.tools_v33 import register_v33_tools
+
         srv = _MockServer()
         engine = _make_mock_engine()
         get_engine = MagicMock(return_value=engine)
@@ -375,6 +396,7 @@ class TestGetSoftPromptsTool:
 
     def _get_tool(self):
         from superlocalmemory.mcp.tools_v33 import register_v33_tools
+
         srv = _MockServer()
         engine = _make_mock_engine()
         get_engine = MagicMock(return_value=engine)
@@ -436,6 +458,7 @@ class TestReapProcessesTool:
 
     def _get_tool(self):
         from superlocalmemory.mcp.tools_v33 import register_v33_tools
+
         srv = _MockServer()
         engine = _make_mock_engine()
         get_engine = MagicMock(return_value=engine)
@@ -447,9 +470,12 @@ class TestReapProcessesTool:
         tool, _ = self._get_tool()
 
         mock_result = {
-            "total_found": 5, "orphans_found": 2,
-            "killed": 0, "skipped": 2,
-            "errors": [], "processes": [],
+            "total_found": 5,
+            "orphans_found": 2,
+            "killed": 0,
+            "skipped": 2,
+            "errors": [],
+            "processes": [],
         }
 
         with patch(
@@ -469,9 +495,12 @@ class TestReapProcessesTool:
         tool, _ = self._get_tool()
 
         mock_result = {
-            "total_found": 5, "orphans_found": 2,
-            "killed": 2, "skipped": 0,
-            "errors": [], "processes": [],
+            "total_found": 5,
+            "orphans_found": 2,
+            "killed": 2,
+            "skipped": 0,
+            "errors": [],
+            "processes": [],
         }
 
         with patch(
@@ -508,6 +537,7 @@ class TestGetRetentionStatsTool:
 
     def _get_tool(self):
         from superlocalmemory.mcp.tools_v33 import register_v33_tools
+
         srv = _MockServer()
         engine = _make_mock_engine()
         get_engine = MagicMock(return_value=engine)
@@ -571,6 +601,7 @@ class TestGetRetentionStatsTool:
         call_args = engine._db.execute.call_args
         assert call_args[0][1] == ("custom",)
 
+
 # ---------------------------------------------------------------------------
 # Maintenance Tools tests
 # ---------------------------------------------------------------------------
@@ -581,6 +612,7 @@ class TestRunMaintenanceTool:
 
     def _get_tool(self):
         from superlocalmemory.mcp.tools_v33 import register_v33_tools
+
         srv = _MockServer()
         engine = _make_mock_engine()
         get_engine = MagicMock(return_value=engine)
@@ -591,19 +623,25 @@ class TestRunMaintenanceTool:
         """run_maintenance behavioral section uses correct ConsolidationWorker args."""
         tool, engine = self._get_tool()
 
-        with patch(
-            "superlocalmemory.learning.consolidation_worker.ConsolidationWorker"
-        ) as MockCW, patch(
-            "superlocalmemory.core.maintenance.run_maintenance",
-            return_value={"updated": 0},
-        ), patch(
-            "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
-        ) as MockSched, patch(
-            "superlocalmemory.math.ebbinghaus.EbbinghausCurve"
+        with (
+            patch("superlocalmemory.learning.consolidation_worker.ConsolidationWorker") as MockCW,
+            patch(
+                "superlocalmemory.core.maintenance.run_maintenance",
+                return_value={"updated": 0},
+            ),
+            patch(
+                "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
+            ) as MockSched,
+            patch("superlocalmemory.math.ebbinghaus.EbbinghausCurve"),
         ):
             MockSched.return_value.run_decay_cycle.return_value = {
-                "total": 0, "active": 0, "warm": 0,
-                "cold": 0, "archive": 0, "forgotten": 0, "transitions": 0,
+                "total": 0,
+                "active": 0,
+                "warm": 0,
+                "cold": 0,
+                "archive": 0,
+                "forgotten": 0,
+                "transitions": 0,
             }
             MockCW.return_value._generate_patterns.return_value = 7
             result = _run(tool())

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -624,6 +624,7 @@ class TestRunMaintenanceTool:
         tool, engine = self._get_tool()
 
         with (
+            patch("superlocalmemory.learning.consolidation_worker.ConsolidationWorker", autospec=True) as MockCW,
             patch(
                 "superlocalmemory.core.maintenance.run_maintenance",
                 return_value={"updated": 0},
@@ -631,7 +632,7 @@ class TestRunMaintenanceTool:
             patch(
                 "superlocalmemory.learning.forgetting_scheduler.ForgettingScheduler"
             ) as MockSched,
-            patch("superlocalmemory.learning.consolidation_worker.ConsolidationWorker", autospec=True) as MockCW,
+            patch("superlocalmemory.math.ebbinghaus.EbbinghausCurve"),
         ):
             MockSched.return_value.run_decay_cycle.return_value = {
                 "total": 0,
@@ -647,6 +648,7 @@ class TestRunMaintenanceTool:
 
         assert result["success"] is True
         assert result["behavioral"]["patterns_mined"] == 7
+        init_args = MockCW.call_args[0]
         expected_memory = engine._db.db_path
         expected_learning = engine._db.db_path.parent / "learning.db"
         MockCW.assert_called_once_with(expected_memory, expected_learning)

--- a/tests/test_mcp/test_mcp_v33_tools.py
+++ b/tests/test_mcp/test_mcp_v33_tools.py
@@ -649,6 +649,6 @@ class TestRunMaintenanceTool:
         assert result["success"] is True
         assert result["behavioral"]["patterns_mined"] == 7
         init_args = MockCW.call_args[0]
-        assert init_args[0] == engine._db.db_path
-        assert init_args[1] == engine._db.db_path.parent / "learning.db"
-        MockCW.return_value._generate_patterns.assert_called_once_with(engine.profile_id, False)
+        expected_memory = engine._db.db_path
+        expected_learning = engine._db.db_path.parent / "learning.db"
+        MockCW.assert_called_once_with(expected_memory, expected_learning)


### PR DESCRIPTION
## Bugs fixed

### 1. `forget` tool — dry_run branch called non-existent methods
`Fixed by querying the existing fact_retention.lifecycle_zone distribution directly via SQL aggregation. This is consistent with get_retention_stats and avoids the hardcoded hours_since=0.0 issue that caused all facts to be classified as active`.

### 2. `run_maintenance` tool — ConsolidationWorker instantiated incorrectly
- Constructor received `engine._db` (DatabaseManager) and `engine._config` instead of file paths.
- `_generate_patterns()` called with wrong arity and return value treated as list (returns int).

Fixed by passing correct SQLite paths and storing the int return directly.

## Tested
Both tools verified in production via Claude Code MCP:
- `forget dry_run=true` → success: true, 1054 facts processed
- `forget dry_run=false` → success: true, 1052 transitions applied
- `run_maintenance` → success: true, 25 behavioral patterns mined