### PR TITLE
fix: remove four latent F-check runtime errors

### DIFF
--- a/src/superlocalmemory/cli/commands.py
+++ b/src/superlocalmemory/cli/commands.py
@@ -12,9 +12,12 @@ Part of Qualixar | Author: Varun Pratap Bhardwaj
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from argparse import Namespace
+
+logger = logging.getLogger(__name__)
 
 
 def _cmd_db_dispatch(args: Namespace) -> None:

--- a/src/superlocalmemory/core/recall_pipeline.py
+++ b/src/superlocalmemory/core/recall_pipeline.py
@@ -17,6 +17,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import os
+
     from superlocalmemory.core.config import SLMConfig
     from superlocalmemory.core.hooks import HookRegistry
     from superlocalmemory.storage.database import DatabaseManager

--- a/src/superlocalmemory/server/routes/events.py
+++ b/src/superlocalmemory/server/routes/events.py
@@ -44,7 +44,9 @@ def _event_to_sse_bridge(event: dict):
                 q.put_nowait(event)
             except _queue.Full:
                 dead_queues.add(q)
-        _sse_queues -= dead_queues
+        # In-place mutation — rebinding (`-=`) would make _sse_queues local,
+        # causing UnboundLocalError on the read above.
+        _sse_queues.difference_update(dead_queues)
 
 
 def register_event_listener():

--- a/src/superlocalmemory/server/routes/v3_api.py
+++ b/src/superlocalmemory/server/routes/v3_api.py
@@ -411,7 +411,6 @@ async def recall_trace(request: Request):
 
 def _record_learning_signals(query: str, results: list) -> None:
     """Record feedback + co-retrieval + confidence boost for any recall."""
-    from pathlib import Path
     from superlocalmemory.core.config import SLMConfig
 
     slm_dir = Path.home() / ".superlocalmemory"


### PR DESCRIPTION
Forwards the existing local candidate on `fix/latent-f-bugs`.

This removes four latent runtime issues caught by Ruff F-checks:
- missing logger binding in `cli/commands.py` exception paths
- `_sse_queues` local rebinding bug in `server/routes/events.py`
- missing `os` import referenced by a type hint in `core/recall_pipeline.py`
- redundant inner `Path` import shadow in `server/routes/v3_api.py`

Validation noted on the local candidate:
- `ruff check --select F821,F811,F823`
- `3387` tests passed, `18` skipped

Existing commit authorship preserved.