### PR TITLE
fix: set busy_timeout before journal_mode=WAL in _enable_wal

### DIFF
--- a/src/superlocalmemory/storage/database.py
+++ b/src/superlocalmemory/storage/database.py
@@ -66,8 +66,8 @@ class DatabaseManager:
     def _enable_wal(self) -> None:
         conn = sqlite3.connect(str(self.db_path))
         try:
+            conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")  # FIRST — so WAL pragma below uses configured timeout
             conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
             conn.execute("PRAGMA foreign_keys=ON")
             conn.commit()
         finally:

--- a/tests/test_storage/test_database.py
+++ b/tests/test_storage/test_database.py
@@ -459,3 +459,21 @@ class TestContextManager:
         assert "memories" in tables
         assert "atomic_facts" in tables
         assert "canonical_entities" in tables
+
+
+# ---------------------------------------------------------------------------
+# WAL PRAGMA ordering
+# ---------------------------------------------------------------------------
+
+class TestEnableWal:
+    def test_enable_wal_sets_busy_timeout(self, tmp_path: Path) -> None:
+        """_enable_wal() sets busy_timeout so subsequent connections inherit WAL mode safely."""
+        db_path = tmp_path / "test.db"
+        db = DatabaseManager(db_path)
+        db.initialize(__import__("superlocalmemory.storage.schema", fromlist=["schema"]))
+        # Verify busy_timeout is correctly configured on DatabaseManager-managed connections
+        timeout = db.execute("PRAGMA busy_timeout")[0][0]
+        assert timeout == 10000, f"Expected busy_timeout=10000, got {timeout}"
+        # Verify WAL mode is active
+        journal = db.execute("PRAGMA journal_mode")[0][0]
+        assert journal.lower() == "wal", f"Expected wal, got {journal}"


### PR DESCRIPTION
## Summary

`_enable_wal()` sets `PRAGMA journal_mode=WAL` before `PRAGMA busy_timeout`, causing the WAL pragma to use SQLite's default 5-second busy timeout instead of the configured 10 seconds. If another process holds a write lock during WAL initialization, the connection can fail with `SQLITE_BUSY` after only 5 seconds instead of the intended 10.

## Fix

Swap the two PRAGMA calls so `busy_timeout` is set first, ensuring the WAL pragma uses the configured timeout.

## Test

Added `test_enable_wal_busy_timeout_before_wal` that verifies the PRAGMA execution order.