### PR TITLE
fix: use logger.exception for engine init failure to capture traceback

### DIFF
--- a/src/superlocalmemory/server/unified_daemon.py
+++ b/src/superlocalmemory/server/unified_daemon.py
@@ -535,8 +535,8 @@ async def lifespan(application: FastAPI):
             application.state.queue_consumer = None
             application.state.recall_queue = None
 
-    except Exception as exc:
-        logger.warning("Engine init failed: %s", exc)
+    except Exception:
+        logger.exception("Engine init failed")  # auto-includes traceback
         application.state.engine = None
         application.state.config = None
 


### PR DESCRIPTION
## Summary

When engine initialization fails in the unified daemon's `lifespan()`, the current code uses `logger.warning("Engine init failed: %s", exc)` which only prints the exception message — not the full traceback. This makes root-cause diagnosis very difficult, especially for issues where the error message alone is insufficient to trace the failure path.

## Fix

Replace `logger.warning("Engine init failed: %s", exc)` with `logger.exception("Engine init failed")`. The `logger.exception()` method automatically includes the full traceback via `sys.exc_info()`, providing complete diagnostic information in the log when engine init fails.