### PR TITLE
fix(learning, macos): isolate LightGBM training in a subprocess to prevent daemon SIGSEGV (dual-libomp OpenMP conflict)

### DIFF
--- a/src/superlocalmemory/learning/lightgbm_subprocess.py
+++ b/src/superlocalmemory/learning/lightgbm_subprocess.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3 | https://qualixar.com | https://varunpratap.com
+
+"""Isolated LightGBM work (retrain + consolidation) — OpenMP-crash guard.
+
+**Why this exists** — the unified daemon serves the HTTP API in-process and,
+by then, has already loaded PyTorch's OpenMP runtime (``torch/lib/libomp.dylib``)
+with *warm* worker threads (the cross-encoder reranker + embedding warm-up at
+startup). Any code path that imports ``lightgbm`` in that same process loads a
+*second* OpenMP runtime — the Homebrew ``libomp.dylib`` that
+``lib_lightgbm.dylib`` links against — which corrupts the shared ``__kmp``
+global state and SIGSEGVs a pre-existing torch OMP worker thread. That
+hard-crashes the whole daemon (observed on macOS / Apple Silicon;
+``DiagnosticReports/Python-*.ips`` shows ``libomp.dylib __kmp_launch_worker``).
+
+Two in-daemon entry points reach LightGBM training:
+  * ``POST /api/learning/retrain``  → legacy ``_retrain_ranker_impl``;
+  * ``POST /api/v3/learning/consolidate`` → ``ConsolidationWorker.run`` whose
+    step 5 trains via the online ``_run_shadow_cycle`` (active model) or the
+    legacy cold-start path.
+
+Both are funnelled through this module so LightGBM only ever trains in a
+**fresh subprocess** that never runs a torch tensor op — torch's OMP pool stays
+dormant there and lightgbm's runtime is the only active one. The mechanism
+mirrors the existing ``embedding_worker`` / ``reranker_worker`` isolation.
+
+Spawned via :func:`run_retrain_isolated` / :func:`run_consolidation_isolated`,
+which use a ``python -c`` bootstrap that imports lightgbm BEFORE the
+``superlocalmemory`` package. That ordering is load-bearing: importing the
+package transitively pulls in torch, and torch-OMP-first-then-lightgbm is
+exactly the sequence that segfaults. A plain ``python -m
+superlocalmemory.learning.lightgbm_subprocess`` would run the package
+``__init__`` (torch) first and crash — do not invoke it that way.
+
+The child emits a single JSON line on stdout — ``{"error": str|null, ...}`` —
+plus a task payload (``trained`` for retrain, ``stats`` for consolidate).
+Exit 0 = ran to completion; non-zero = handled failure. Either way the parent
+(the daemon) keeps running.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Wall-clock ceilings. A retrain is 50 boosting rounds on ≤2000 rows (seconds);
+# a full consolidation cycle also decays/dedups/mines/graph-analyses, so it
+# gets more headroom.
+RETRAIN_TIMEOUT_SEC = 300
+CONSOLIDATE_TIMEOUT_SEC = 600
+
+
+# ---------------------------------------------------------------------------
+# Child-side task implementations (run in the isolated subprocess).
+# ---------------------------------------------------------------------------
+
+def _retrain(learning_db: str, profile_id: str, *, include_synthetic: bool) -> bool:
+    """Legacy ranker retrain in this (lightgbm-first) process. Returns trained."""
+    import lightgbm  # noqa: F401  (import-order side effect is intentional)
+
+    from superlocalmemory.learning.ranker_retrain_legacy import (
+        _retrain_ranker_impl,
+    )
+
+    return bool(
+        _retrain_ranker_impl(
+            learning_db, profile_id, include_synthetic=include_synthetic,
+        )
+    )
+
+
+def _consolidate(
+    memory_db: str, learning_db: str, profile_id: str, *, dry_run: bool,
+) -> dict:
+    """Full consolidation cycle (incl. step-5 LightGBM training). Returns stats."""
+    import lightgbm  # noqa: F401  (import-order side effect is intentional)
+
+    from superlocalmemory.learning.consolidation_worker import (
+        ConsolidationWorker,
+    )
+
+    worker = ConsolidationWorker(memory_db, learning_db)
+    return worker.run(profile_id, dry_run=dry_run)
+
+
+def _emit(obj: dict) -> None:
+    """Write the verdict as a single JSON line (default=str for safety)."""
+    sys.stdout.write(json.dumps(obj, default=str) + "\n")
+    sys.stdout.flush()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="slm-lightgbm-subprocess")
+    parser.add_argument("--task", choices=["retrain", "consolidate"], default="retrain")
+    parser.add_argument("--learning-db", required=True)
+    parser.add_argument("--memory-db")
+    parser.add_argument("--profile", default="default")
+    parser.add_argument("--include-synthetic", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    result: dict = {"error": None}
+    try:
+        if args.task == "retrain":
+            result["trained"] = _retrain(
+                args.learning_db, args.profile,
+                include_synthetic=args.include_synthetic,
+            )
+        else:
+            if not args.memory_db:
+                raise ValueError("--memory-db is required for the consolidate task")
+            result["stats"] = _consolidate(
+                args.memory_db, args.learning_db, args.profile,
+                dry_run=args.dry_run,
+            )
+    except Exception as exc:  # noqa: BLE001
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        _emit(result)
+        return 1
+
+    _emit(result)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Caller-side helpers — spawn the child in an isolated process.
+# ---------------------------------------------------------------------------
+
+def _run_isolated(task_args: list[str], *, timeout_sec: int) -> dict:
+    """Spawn the child with lightgbm imported first; return its JSON verdict.
+
+    Never raises for the expected failure modes (non-zero exit, timeout,
+    native crash with no JSON) — encodes them in an ``error`` key so the
+    calling daemon stays up no matter what.
+    """
+    # The leading ``import lightgbm`` is load-bearing: it must run BEFORE the
+    # superlocalmemory package (which transitively imports torch). ``-c`` is
+    # the only way to guarantee that ordering — ``-m superlocalmemory.…`` runs
+    # the package __init__ (torch) first and would reintroduce the crash.
+    bootstrap = (
+        "import lightgbm; "
+        "from superlocalmemory.learning.lightgbm_subprocess import main; "
+        "raise SystemExit(main())"
+    )
+    cmd = [sys.executable, "-c", bootstrap, *task_args]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": f"timed out after {timeout_sec}s"}
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"spawn failed: {exc}"}
+
+    # The verdict is the last JSON line on stdout. Parse defensively — a native
+    # crash in the child would leave no JSON, which we surface plainly.
+    for line in reversed((proc.stdout or "").splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            return json.loads(line)
+        except ValueError:
+            continue
+
+    tail = (proc.stderr or "").strip()[-500:]
+    return {
+        "error": (
+            f"subprocess produced no verdict (exit={proc.returncode}). "
+            f"stderr tail: {tail}"
+        ),
+    }
+
+
+def run_retrain_isolated(
+    learning_db: str | Path,
+    profile_id: str,
+    *,
+    include_synthetic: bool = False,
+    timeout_sec: int = RETRAIN_TIMEOUT_SEC,
+) -> dict:
+    """Train the ranker in a subprocess. Returns ``{"trained": bool, "error": ...}``."""
+    args = [
+        "--task", "retrain",
+        "--learning-db", str(learning_db),
+        "--profile", profile_id,
+    ]
+    if include_synthetic:
+        args.append("--include-synthetic")
+    verdict = _run_isolated(args, timeout_sec=timeout_sec)
+    verdict.setdefault("trained", False)
+    verdict.setdefault("error", None)
+    return verdict
+
+
+def run_consolidation_isolated(
+    memory_db: str | Path,
+    learning_db: str | Path,
+    profile_id: str,
+    *,
+    dry_run: bool = False,
+    timeout_sec: int = CONSOLIDATE_TIMEOUT_SEC,
+) -> dict:
+    """Run the full consolidation cycle in a subprocess (its step-5 training
+    would otherwise crash the torch-warm daemon).
+
+    Returns ``{"stats": dict|None, "error": str|None}``.
+    """
+    args = [
+        "--task", "consolidate",
+        "--memory-db", str(memory_db),
+        "--learning-db", str(learning_db),
+        "--profile", profile_id,
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    verdict = _run_isolated(args, timeout_sec=timeout_sec)
+    verdict.setdefault("stats", None)
+    verdict.setdefault("error", None)
+    return verdict
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/superlocalmemory/server/routes/learning.py
+++ b/src/superlocalmemory/server/routes/learning.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter
+from fastapi.concurrency import run_in_threadpool
 
 from .helpers import get_active_profile, MEMORY_DIR
 
@@ -597,16 +598,31 @@ async def learning_retrain(data: dict | None = None):
         data and data.get("include_synthetic")
     ) if isinstance(data, dict) else False
     try:
-        from superlocalmemory.learning.consolidation_worker import (
-            _retrain_ranker_impl,
+        # Train OUT OF PROCESS. The daemon already has torch's OpenMP runtime
+        # loaded with warm worker threads; importing lightgbm in-process loads
+        # a second libomp and SIGSEGVs the whole daemon (see
+        # retrain_subprocess module docstring). Isolation is the fix.
+        from superlocalmemory.learning.lightgbm_subprocess import (
+            run_retrain_isolated,
         )
         profile_id = get_active_profile() or "default"
-        trained = _retrain_ranker_impl(
+        result = await run_in_threadpool(
+            run_retrain_isolated,
             LEARNING_DB,
             profile_id,
             include_synthetic=include_synthetic,
         )
-        if trained:
+        if result.get("error"):
+            logger.error("learning_retrain failed: %s", result["error"])
+            return {"success": False, "error": result["error"]}
+        if result.get("trained"):
+            # Drop the cached model so the next recall reloads the freshly
+            # trained one the subprocess just persisted to learning.db.
+            try:
+                from superlocalmemory.learning.model_cache import invalidate
+                invalidate(profile_id)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.debug("model cache invalidate failed: %s", exc)
             return {
                 "success": True,
                 "trained": True,

--- a/src/superlocalmemory/server/routes/v3_api.py
+++ b/src/superlocalmemory/server/routes/v3_api.py
@@ -806,15 +806,37 @@ async def run_consolidation(request: Request):
     try:
         body = await request.json()
         dry_run = body.get("dry_run", False)
-        from superlocalmemory.learning.consolidation_worker import ConsolidationWorker
+        # Run the full cycle OUT OF PROCESS. Step 5 trains the LightGBM ranker
+        # (online _run_shadow_cycle or legacy cold-start); importing lightgbm
+        # in the torch-warm daemon loads a second libomp and SIGSEGVs it (see
+        # lightgbm_subprocess module docstring). Isolation is the fix.
+        from superlocalmemory.learning.lightgbm_subprocess import (
+            run_consolidation_isolated,
+        )
         from superlocalmemory.core.config import SLMConfig
         from superlocalmemory.server.routes.helpers import DB_PATH
-        worker = ConsolidationWorker(
-            memory_db=str(DB_PATH),
-            learning_db=str(DB_PATH.parent / "learning.db"),
-        )
+        from fastapi.concurrency import run_in_threadpool
+
         config = SLMConfig.load()
-        stats = worker.run(config.active_profile, dry_run=dry_run)
+        learning_db = DB_PATH.parent / "learning.db"
+        result = await run_in_threadpool(
+            run_consolidation_isolated,
+            str(DB_PATH),
+            str(learning_db),
+            config.active_profile,
+            dry_run=dry_run,
+        )
+        if result.get("error"):
+            return {"success": False, "error": result["error"]}
+        # Step-5 training may have promoted a new model — drop the daemon's
+        # cached model so the next recall reloads it from learning.db.
+        if not dry_run:
+            try:
+                from superlocalmemory.learning.model_cache import invalidate
+                invalidate(config.active_profile)
+            except Exception:
+                pass
+        stats = result.get("stats") or {}
         return {"success": True, **stats}
     except Exception as exc:
         return {"success": False, "error": str(exc)}

--- a/tests/test_learning/test_lightgbm_subprocess.py
+++ b/tests/test_learning/test_lightgbm_subprocess.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3
+
+"""Tests for isolated LightGBM work (OpenMP-crash guard).
+
+The unified daemon serves the HTTP API in-process with PyTorch's OpenMP
+runtime already loaded and warm. Importing lightgbm in that same process loads
+a second libomp and SIGSEGVs the whole daemon. ``run_retrain_isolated`` and
+``run_consolidation_isolated`` train out-of-process so that can never happen.
+
+These tests lock in the load-bearing properties of the fix without depending
+on a real training run:
+  * the spawn imports lightgbm BEFORE the ``superlocalmemory`` package
+    (the import ordering that avoids the crash) and never uses ``-m``;
+  * a non-zero / crashing child is reported as an error, never raised, so the
+    daemon stays up;
+  * a well-formed JSON verdict is parsed and returned verbatim;
+  * each task forwards the right CLI flags.
+"""
+
+from __future__ import annotations
+
+import json
+
+from superlocalmemory.learning import lightgbm_subprocess as rs
+
+
+class _FakeProc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _capture_cmd(monkeypatch, stdout):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc(stdout=stdout)
+
+    monkeypatch.setattr(rs.subprocess, "run", fake_run)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Import ordering — the actual crash guard.
+# ---------------------------------------------------------------------------
+
+def test_bootstrap_imports_lightgbm_before_package(monkeypatch):
+    """Child must import lightgbm first — torch-OMP-first crashes."""
+    captured = _capture_cmd(monkeypatch, json.dumps({"trained": False, "error": None}))
+    rs.run_retrain_isolated("/tmp/learning.db", "default")
+
+    cmd = captured["cmd"]
+    assert "-c" in cmd
+    assert "-m" not in cmd  # -m would run the package __init__ (torch) first
+    bootstrap = cmd[cmd.index("-c") + 1]
+    assert bootstrap.index("import lightgbm") < bootstrap.index("superlocalmemory")
+
+
+def test_consolidate_bootstrap_also_lightgbm_first(monkeypatch):
+    captured = _capture_cmd(monkeypatch, json.dumps({"stats": {}, "error": None}))
+    rs.run_consolidation_isolated("/tmp/mem.db", "/tmp/learning.db", "default")
+
+    cmd = captured["cmd"]
+    assert "-c" in cmd and "-m" not in cmd
+    bootstrap = cmd[cmd.index("-c") + 1]
+    assert bootstrap.index("import lightgbm") < bootstrap.index("superlocalmemory")
+
+
+# ---------------------------------------------------------------------------
+# Flag forwarding.
+# ---------------------------------------------------------------------------
+
+def test_retrain_flags_forwarded(monkeypatch):
+    captured = _capture_cmd(monkeypatch, json.dumps({"trained": True, "error": None}))
+    rs.run_retrain_isolated("/tmp/learning.db", "p1", include_synthetic=True)
+    cmd = captured["cmd"]
+    assert "--task" in cmd and cmd[cmd.index("--task") + 1] == "retrain"
+    assert "--learning-db" in cmd and "/tmp/learning.db" in cmd
+    assert "--profile" in cmd and "p1" in cmd
+    assert "--include-synthetic" in cmd
+
+    captured = _capture_cmd(monkeypatch, json.dumps({"trained": False, "error": None}))
+    rs.run_retrain_isolated("/tmp/learning.db", "p1", include_synthetic=False)
+    assert "--include-synthetic" not in captured["cmd"]
+
+
+def test_consolidate_flags_forwarded(monkeypatch):
+    captured = _capture_cmd(monkeypatch, json.dumps({"stats": {"retrained": True}, "error": None}))
+    rs.run_consolidation_isolated("/tmp/mem.db", "/tmp/learning.db", "p2", dry_run=True)
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--task") + 1] == "consolidate"
+    assert "--memory-db" in cmd and "/tmp/mem.db" in cmd
+    assert "--learning-db" in cmd and "/tmp/learning.db" in cmd
+    assert "--profile" in cmd and "p2" in cmd
+    assert "--dry-run" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Failure handling — never raise, always keep the daemon alive.
+# ---------------------------------------------------------------------------
+
+def test_native_crash_reported_not_raised(monkeypatch):
+    """A SIGSEGV in the child (no JSON, negative exit) → error dict, no raise."""
+    monkeypatch.setattr(
+        rs.subprocess, "run",
+        lambda cmd, **kw: _FakeProc(stdout="", stderr="boom", returncode=-11),
+    )
+    result = rs.run_retrain_isolated("/tmp/learning.db", "default")
+    assert result["trained"] is False
+    assert "no verdict" in result["error"] and "exit=-11" in result["error"]
+
+
+def test_consolidate_native_crash_reported(monkeypatch):
+    monkeypatch.setattr(
+        rs.subprocess, "run",
+        lambda cmd, **kw: _FakeProc(stdout="", stderr="segfault", returncode=-11),
+    )
+    result = rs.run_consolidation_isolated("/tmp/mem.db", "/tmp/learning.db", "default")
+    assert result["stats"] is None
+    assert "no verdict" in result["error"]
+
+
+def test_timeout_reported_not_raised(monkeypatch):
+    import subprocess as _sp
+
+    def fake_run(cmd, **kwargs):
+        raise _sp.TimeoutExpired(cmd, kwargs.get("timeout", 1))
+
+    monkeypatch.setattr(rs.subprocess, "run", fake_run)
+    result = rs.run_retrain_isolated("/tmp/learning.db", "default", timeout_sec=7)
+    assert result["trained"] is False and "timed out" in result["error"]
+
+
+def test_verdict_parsed_from_last_json_line(monkeypatch):
+    """Deprecation warnings / log noise before the JSON verdict are ignored."""
+    noisy = (
+        "DeprecationWarning: ranker_retrain_legacy ...\n"
+        "some other log line\n"
+        + json.dumps({"trained": True, "error": None}) + "\n"
+    )
+    monkeypatch.setattr(rs.subprocess, "run", lambda cmd, **kw: _FakeProc(stdout=noisy))
+    result = rs.run_retrain_isolated("/tmp/learning.db", "default")
+    assert result == {"trained": True, "error": None}
+
+
+# ---------------------------------------------------------------------------
+# Child dispatch (main) — exercised in-process; safe because these tasks
+# short-circuit before any heavy training on an empty/missing DB.
+# ---------------------------------------------------------------------------
+
+def test_main_consolidate_requires_memory_db(capsys):
+    rc = rs.main(["--task", "consolidate", "--learning-db", "/tmp/x.db"])
+    assert rc == 1
+    verdict = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert "--memory-db" in verdict["error"]


### PR DESCRIPTION
 ## Summary

  On macOS, clicking **"Train model now"** in the dashboard Brain pane
  (`POST /api/learning/retrain`) — and calling `POST /api/v3/learning/consolidate`
  — hard-crashes the unified daemon. The HTTP call returns an empty reply and the
  daemon PID changes (it gets auto-restarted). No Python traceback is logged,
  because the process dies on a native signal.

  This PR runs all LightGBM training in an isolated subprocess so it can never
  crash the daemon, mirroring the existing `embedding_worker` / `reranker_worker`
  isolation pattern.

  ## Root cause

  The daemon serves the HTTP API **in-process** and, by then, has PyTorch's
  OpenMP runtime (`torch/lib/libomp.dylib`) loaded with **warm worker threads**
  (the cross-encoder reranker + embedding warm-up at startup). When a request
  handler imports `lightgbm` and trains, LightGBM loads a **second** OpenMP
  runtime — the Homebrew `libomp.dylib` that `lib_lightgbm.dylib` links against —
  and forks its own OMP worker pool. Two live OpenMP runtimes in one process
  corrupt the shared `__kmp` state, and a worker thread segfaults:

  ```
  Termination: SIGSEGV (EXC_BAD_ACCESS)
  Faulting thread: libomp.dylib __kmp_launch_worker
                   → __kmp_fork_barrier → __kmp_suspend_initialize_thread
  ```
  (`~/Library/Logs/DiagnosticReports/Python-*.ips`)

  ### An OpenMP conflict, not a model load path issue (also suggested as a trigger)

  Experiments on my machine (Python 3.14 / macOS ARM64 / LightGBM 4.6.0)
  provide a strong candidate root cause:

  | Condition | `model_file=` | `model_str=` | Outcome |
  |---|---|---|---|
  | Clean process, **no torch** | ✅ | ✅ | not a standalone LightGBM bug |
  | **torch warm**, default threads | 💥 SIGSEGV | 💥 SIGSEGV | crashes at the first booster/training op |
  | torch warm + `OMP_NUM_THREADS=1` | ✅ | ✅ | no OMP thread-forking, no issue |

  The likely issue is **torch's OpenMP pool being warm when LightGBM first forks
  its own pool**. Import **order** matters too: lightgbm-first then
  torch is safe; torch-warm-first then lightgbm crashes.

  The test suite mostly survives because `conftest.py` sets
  `OMP_NUM_THREADS=1` (serial OpenMP, no parallel fork). The **daemon** does not have this setting and runs parallel OpenMP, so it (daemon) crashes in production.

  ## Reproduction

  No SuperLocalMemory code involved. Requires `torch`,
  `lightgbm`, and `numpy` in one environment (Python 3.14 / macOS Apple Silicon /
  LightGBM 4.6.0):

  ```python
  """torch-warm process + LightGBM => SIGSEGV (macOS / Apple Silicon).
  Dies with SIGSEGV and no traceback on affected platforms; prints DONE elsewhere."""
  import sys
  def step(m): sys.stderr.write(m + "\n"); sys.stderr.flush()

  import numpy as np
  import torch

  step("1) warming torch's OpenMP pool (parallel matmul)")
  _ = (torch.rand(1500, 1500) @ torch.rand(1500, 1500)).sum().item()

  step("2) importing lightgbm + training (forks LightGBM's own OpenMP workers)")
  import lightgbm as lgb
  X = np.random.RandomState(0).rand(300, 6); y = (X[:, 0] > 0.5).astype(int)
  booster = lgb.train({"objective": "binary", "verbosity": -1},
                      lgb.Dataset(X, label=y), num_boost_round=8)

  step("3) loading the booster back")
  lgb.Booster(model_str=booster.model_to_string())

  step("DONE — no crash on this platform")
  ```

  Observed:

  ```console
  $ python repro.py
  1) warming torch's OpenMP pool (parallel matmul)
  2) importing lightgbm + training (forks LightGBM's own OpenMP workers)
  [1]    <pid> segmentation fault  python repro.py          # exit 139, no traceback

  $ OMP_NUM_THREADS=1 python repro.py
  1) warming torch's OpenMP pool (parallel matmul)
  2) importing lightgbm + training (forks LightGBM's own OpenMP workers)
  3) loading the booster back
  DONE — no crash on this platform                          # exit 0
  ```

  The crash fires at step 2 — the first LightGBM OpenMP fork after torch's pool is
  warm — the daemon's cold-start retrain path. Swap the order
  (import + train LightGBM *before* warming torch) and it also runs clean,
  confirming the issue is two live OpenMP runtimes in one process rather than
  SuperLocalMemory code. The daemon hits this because the reranker/embedding
  warm-up makes torch's OpenMP pool warm before any training request arrives.

  ## Reachable crash sites

  - `POST /api/learning/retrain` → `_retrain_ranker_impl`
  - `POST /api/v3/learning/consolidate` → `ConsolidationWorker.run()` step 5
    (online `_run_shadow_cycle` or legacy cold-start)

  Not affected: the maintenance endpoints / MCP `run_maintenance` (pattern mining
  only, no LightGBM), the CLI `slm consolidate --cognitive` (CCQ pipeline), and
  the background schedulers (none train LightGBM) — so there is no silent
  on-a-timer crash; every crash requires an explicit user/API call.

  ## The proposed fix

  A new module `learning/lightgbm_subprocess.py` exposing `run_retrain_isolated()`
  and `run_consolidation_isolated()`. They spawn a fresh process via a
  `python -c "import lightgbm; from ... import main; ..."` bootstrap that imports
  `lightgbm` **before** the `superlocalmemory` package (which transitively imports
  torch). This ordering is critical — `python -m superlocalmemory…` would run
  the package `__init__` (torch) first and crash. The child never runs a
  torch tensor op, so torch's OMP pool stays dormant and LightGBM's runtime is the
  only active pool, thereby avoiding the crash scenario.

  - The child emits a single JSON verdict line; the parent parses it and **never
    raises** — a native child crash is reported as an error, keeping the daemon up.
  - On success the daemon calls `model_cache.invalidate(profile)` so the freshly
    trained model is reloaded.
  - Both endpoints call the helpers via `run_in_threadpool` to avoid blocking the
    event loop.

  ## Alternatives considered

  - **`OMP_NUM_THREADS=1` in the daemon** — would prevent the crash, but serializes
    *all* torch/sklearn/LightGBM parallelism in the daemon (hurts reranker and
    embedding throughput). Subprocess isolation keeps the daemon parallel and
    isolates only training.
  - **Loading boosters via `model_file=` (temp file)** — does **not** fix it; under
    torch-warm, `model_file=` segfaults too (see table).
  - **Unifying the libomp copies via `install_name_tool`** — fragile; `pip` reinstall
    re-runs delocate and resets install names.

  ## Testing

  - New `tests/test_learning/test_lightgbm_subprocess.py`: lightgbm-first bootstrap
    ordering, flag forwarding, and crash/timeout/verdict handling for both tasks.
  - Manual end-to-end: the daemon PID is **stable** across both endpoints
    (HTTP 200) where it previously crashed.

  ## Notes

  - `/api/learning/retrain` continues to use the (deprecated) cold-start
    `_retrain_ranker_impl`, because the button's "train + activate now" semantics
    have no non-deprecated replacement yet (the online `_run_shadow_cycle` only
    persists a *candidate*; promotion is deferred to the shadow-router). This PR
    centralizes that deprecated reference into a single swappable function
    (`lightgbm_subprocess._retrain`) so removing the legacy path later is a
    one-line change.
 - Platform: the SIGSEGV is observed on macOS / Apple Silicon (wheel-packaging quirk — multiple vendored libomp copies). The fix isolates training for all OS; on Linux/Windows the cost is an infrequent subprocess spawn but the proposed fix yields a "training can't crash the daemon" guarantee across all OS.
 - 
  ## Files changed

  - `src/superlocalmemory/learning/lightgbm_subprocess.py` (new)
  - `src/superlocalmemory/server/routes/learning.py`
  - `src/superlocalmemory/server/routes/v3_api.py`
  - `tests/test_learning/test_lightgbm_subprocess.py` (new)