### PR TITLE
fix: McpEmbedderProxy — MCP LIGHT engine always has embedder=None, semantic search silently degraded

### DIFF
--- a/src/superlocalmemory/core/engine.py
+++ b/src/superlocalmemory/core/engine.py
@@ -124,6 +124,9 @@ class MemoryEngine:
 
         self._init_db_layer()
 
+        if self._capabilities is Capabilities.LIGHT:
+            self._embedder = self._try_init_proxy()
+
         if self._capabilities is Capabilities.FULL:
             self._init_heavy_layer()
 
@@ -137,6 +140,26 @@ class MemoryEngine:
         if self._capabilities is Capabilities.FULL:
             # Replay pending async writes only when heavy layer is available.
             self._process_pending_memories()
+
+    def _try_init_proxy(self):
+        """Try to initialise McpEmbedderProxy when running as LIGHT engine.
+
+        The MCP server uses Capabilities.LIGHT to stay lean (~60 MB).
+        Without this, _embedder is always None: every memory stored via
+        MCP receives embedding=NULL and semantic search is silently absent.
+
+        Falls back gracefully: if the daemon is not running, returns None
+        and the LIGHT engine continues with 5-channel retrieval.
+        """
+        try:
+            from superlocalmemory.core.mcp_embedder_proxy import McpEmbedderProxy
+            proxy = McpEmbedderProxy(dimension=self._config.embedding.dimension)
+            if proxy.is_available:
+                logger.info("LIGHT engine: using McpEmbedderProxy for semantic channel")
+                return proxy
+        except Exception as exc:
+            logger.debug("McpEmbedderProxy unavailable: %s", exc)
+        return None
 
     def _init_db_layer(self) -> None:
         from superlocalmemory.storage import schema

--- a/src/superlocalmemory/core/mcp_embedder_proxy.py
+++ b/src/superlocalmemory/core/mcp_embedder_proxy.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3 | https://qualixar.com | https://varunpratap.com
+"""McpEmbedderProxy — lightweight embedder for LIGHT engine in MCP server.
+
+Delegates embed_batch() to the daemon via HTTP instead of spawning a second
+ONNX worker. Keeps the MCP process at ~60 MB while giving the LIGHT engine
+a fully-functional semantic channel.
+
+Used by MemoryEngine._try_init_proxy() when Capabilities.LIGHT is requested.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class McpEmbedderProxy:
+    """Drop-in EmbeddingService replacement that proxies via daemon HTTP.
+
+    The daemon already holds a warm ONNX worker; this class asks it for
+    vectors over a local HTTP call instead of creating a second worker.
+    The MCP process memory footprint stays at ~60 MB.
+
+    The ``_is_proxy = True`` class attribute allows ``health()`` in
+    ``tools_v3.py`` to report ``"proxy_via_daemon"`` instead of ``"ok"``,
+    so operators can distinguish a proxied embedder from a local one.
+    """
+
+    _is_proxy = True
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8765",
+        dimension: int = 768,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._dimension = dimension
+
+    @property
+    def is_available(self) -> bool:
+        """Return True if the daemon is reachable on /api/stats."""
+        try:
+            import httpx
+            r = httpx.get(self._base_url + "/api/stats", timeout=2.0)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def embed(self, text: str) -> list[float] | None:
+        result = self.embed_batch([text])
+        return result[0] if result else None
+
+    def embed_batch(self, texts: list[str]) -> list[list[float] | None]:
+        """Embed a batch of texts via POST /api/embed on the daemon."""
+        try:
+            import httpx
+            r = httpx.post(
+                self._base_url + "/api/embed",
+                json={"texts": texts},
+                timeout=30.0,
+            )
+            r.raise_for_status()
+            return r.json()["vectors"]
+        except Exception as exc:
+            logger.warning("McpEmbedderProxy.embed_batch failed: %s", exc)
+            return [None] * len(texts)
+
+    def compute_fisher_params(
+        self, embedding: list[float],
+    ) -> tuple[list[float], list[float]]:
+        """Fisher-Rao params are computed by the daemon; return empty here."""
+        return [], []
+
+    def unload(self) -> None:
+        pass

--- a/src/superlocalmemory/mcp/tools_v3.py
+++ b/src/superlocalmemory/mcp/tools_v3.py
@@ -162,8 +162,14 @@ def register_v3_tools(server, get_engine: Callable) -> None:
             }
 
             # Embedding service
+            _emb = engine._embedder
+            _emb_status = (
+                "proxy_via_daemon" if _emb and getattr(_emb, "_is_proxy", False)
+                else "ok" if _emb
+                else "unavailable"
+            )
             status["components"]["embedder"] = {
-                "status": "ok" if engine._embedder else "unavailable",
+                "status": _emb_status,
                 "model": engine._config.embedding.model_name,
             }
 

--- a/src/superlocalmemory/server/routes/stats.py
+++ b/src/superlocalmemory/server/routes/stats.py
@@ -11,12 +11,30 @@ import logging
 from collections import defaultdict
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from .helpers import get_db_connection, dict_factory, get_active_profile, DB_PATH, MEMORY_DIR
 
 logger = logging.getLogger("superlocalmemory.routes.stats")
 router = APIRouter()
+
+
+@router.post("/api/embed")
+async def embed_texts(request: Request):
+    """Embed texts via the daemon's in-process embedder.
+
+    Used by McpEmbedderProxy so the MCP LIGHT-engine can obtain embeddings
+    without spawning a second ONNX worker process.
+    """
+    engine = getattr(request.app.state, "engine", None)
+    if engine is None or engine._embedder is None:
+        raise HTTPException(status_code=503, detail="Embedder unavailable")
+    body = await request.json()
+    texts = body.get("texts", [])
+    if not texts:
+        raise HTTPException(status_code=400, detail="texts required")
+    vectors = engine._embedder.embed_batch(texts)
+    return {"vectors": vectors, "dim": engine._embedder.dimension}
 
 
 @router.get("/api/stats")


### PR DESCRIPTION
### Problem

`mcp/server.py` creates `MemoryEngine(config, capabilities=Capabilities.LIGHT)`.
`Capabilities.LIGHT` skips `_init_heavy_layer()` → `_embedder = None` permanently.

Every `remember` call via MCP stores an `AtomicFact` with `embedding = NULL`.
Semantic search is silently absent — no warning, no error.

Additionally, `health()` in `tools_v3.py` returns `"status": "full_6_channel"` even when the semantic channel is dead.

| Component | Capabilities | Embedder | Semantic |
|-----------|-------------|---------|---------|
| systemd daemon | FULL | OK (ONNX worker) | ✅ |
| MCP server (`slm mcp`) | LIGHT | **None** | ❌ |
| slm CLI | FULL | OK | ✅ |

### Solution: `McpEmbedderProxy`

A lightweight proxy that delegates `embed_batch()` to the daemon's `/api/embed` endpoint over localhost HTTP. One ONNX worker total (in the daemon). MCP stays at ~60 MB.

```
MCP server (LIGHT, ~60 MB)             Daemon (FULL, ~2 GB)
  engine._embedder                       engine._embedder
    = McpEmbedderProxy    →                = ONNX worker
      .embed_batch(texts)  POST /api/embed   .embed_batch(texts)
```

### Files changed

| File | Change |
|------|--------|
| `core/mcp_embedder_proxy.py` | **new** — proxy class with `_is_proxy=True` marker |
| `core/engine.py` | add `_try_init_proxy()`, call it in `initialize()` for LIGHT mode |
| `mcp/tools_v3.py` | `health()` reports `"proxy_via_daemon"` / `"ok"` / `"unavailable"` |
| `server/routes/stats.py` | add `POST /api/embed` endpoint used by the proxy |

### Fallback behaviour

`_try_init_proxy()` returns `None` if the daemon is not reachable. The LIGHT engine then continues with 5-channel retrieval (BM25, entity graph, temporal, spreading activation, hopfield) — identical to current behaviour. **No breaking changes.**

### Verification

```bash
# /api/embed returns 768-dim vectors
curl -X POST http://localhost:8765/api/embed \
  -H "Content-Type: application/json" \
  -d '{"texts": ["test"]}'
# → {"vectors": [[...768 floats...]], "dim": 768}

# health reflects proxy state
# mcp__superlocalmemory__health → components.embedder.status = "proxy_via_daemon"

# new atomic_facts now have non-NULL embedding
python3 -c "
import sqlite3
c = sqlite3.connect('~/.superlocalmemory/memory.db').cursor()
c.execute('SELECT count(*), count(embedding) FROM atomic_facts')
print(c.fetchone())  # both counts equal after fix
"
```

### Environment tested

- SLM 3.5.7, Mode A, NixOS
- daemon on :8765, MCP via stdio