### PR TITLE
feat: add scope and shared_with columns for multi-scope memory (PR 1/3)

### DIFF
--- a/src/superlocalmemory/storage/migration_runner.py
+++ b/src/superlocalmemory/storage/migration_runner.py
@@ -51,6 +51,7 @@ from superlocalmemory.storage.migrations import (
     M013_bi_temporal_columns as _M013,
     M014_v345_scale_ready as _M014,
     M015_add_pinned_column as _M015,
+    M016_add_scope_support as _M016,
 )
 
 # Map migration name → module (used for the optional ``verify(conn)`` hook
@@ -71,6 +72,7 @@ _MODULES = {
     _M013.NAME: _M013,
     _M014.NAME: _M014,
     _M015.NAME: _M015,
+    _M016.NAME: _M016,
 }
 
 logger = logging.getLogger(__name__)
@@ -134,6 +136,9 @@ DEFERRED_MIGRATIONS: list[Migration] = [
     Migration(name=_M014.NAME, db_target="memory", ddl=_M014.DDL),
     # M015 adds pinned column to atomic_facts (v3.4.65 core-memory pins).
     Migration(name=_M015.NAME, db_target="memory", ddl=_M015.DDL),
+    # M016 adds scope and shared_with columns to 5 core tables for
+    # multi-scope memory support (personal/global/shared).
+    Migration(name=_M016.NAME, db_target="memory", ddl=_M016.DDL),
 ]
 
 

--- a/src/superlocalmemory/storage/migrations/M016_add_scope_support.py
+++ b/src/superlocalmemory/storage/migrations/M016_add_scope_support.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory v3.6.13
+
+"""M016 — scope and shared_with columns on core tables (memory.db, deferred).
+
+Adds two columns to each of the 5 core tables for multi-scope memory support:
+
+    scope       TEXT NOT NULL DEFAULT 'personal'  — personal | global
+    shared_with TEXT                             — JSON array of profile_ids
+
+Existing data retains scope='personal' (backward compatible). New indexes
+on ``scope`` and ``(profile_id, scope)`` speed up scope-filtered queries.
+
+Deferred like M006, M011, and M013 because the core tables are bootstrapped
+at engine init, not at migration time. Daemon lifespan calls
+``apply_deferred`` right after engine init so these columns materialise
+on first boot after upgrade.
+
+Author: Varun Pratap Bhardwaj / Qualixar
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+NAME = "M016_add_scope_support"
+DB_TARGET = "memory"
+
+TABLES = [
+    "memories",
+    "atomic_facts",
+    "canonical_entities",
+    "graph_edges",
+    "temporal_events",
+]
+
+DDL = ";".join(
+    [f"ALTER TABLE {t} ADD COLUMN scope TEXT NOT NULL DEFAULT 'personal'" for t in TABLES]
+    + [f"ALTER TABLE {t} ADD COLUMN shared_with TEXT" for t in TABLES]
+    + [f"CREATE INDEX IF NOT EXISTS idx_{t}_scope ON {t}(scope)" for t in TABLES]
+    + [
+        f"CREATE INDEX IF NOT EXISTS idx_{t}_profile_scope ON {t}(profile_id, scope)"
+        for t in TABLES
+    ]
+)
+
+
+def verify(conn: sqlite3.Connection) -> bool:
+    """Check if migration already applied by inspecting atomic_facts columns."""
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(atomic_facts)").fetchall()}
+    except sqlite3.Error:
+        return False
+    return "scope" in cols

--- a/src/superlocalmemory/storage/models.py
+++ b/src/superlocalmemory/storage/models.py
@@ -119,6 +119,8 @@ class MemoryRecord:
 
     memory_id: str = field(default_factory=_new_id)
     profile_id: str = "default"
+    scope: str = "personal"
+    shared_with: list[str] | None = None
     content: str = ""
     session_id: str = ""
     speaker: str = ""              # Who said this
@@ -139,6 +141,8 @@ class AtomicFact:
     fact_id: str = field(default_factory=_new_id)
     memory_id: str = ""            # Source memory this was extracted from
     profile_id: str = "default"
+    scope: str = "personal"
+    shared_with: list[str] | None = None
     content: str = ""              # Atomic fact statement
     fact_type: FactType = FactType.SEMANTIC
 
@@ -193,6 +197,8 @@ class CanonicalEntity:
 
     entity_id: str = field(default_factory=_new_id)
     profile_id: str = "default"
+    scope: str = "personal"
+    shared_with: list[str] | None = None
     canonical_name: str = ""
     entity_type: str = ""          # person / place / org / concept / event
     first_seen: str = field(default_factory=_now)
@@ -251,6 +257,8 @@ class TemporalEvent:
 
     event_id: str = field(default_factory=_new_id)
     profile_id: str = "default"
+    scope: str = "personal"
+    shared_with: list[str] | None = None
     entity_id: str = ""            # FK to CanonicalEntity
     fact_id: str = ""              # FK to AtomicFact
     observation_date: str | None = None
@@ -266,6 +274,8 @@ class GraphEdge:
 
     edge_id: str = field(default_factory=_new_id)
     profile_id: str = "default"
+    scope: str = "personal"
+    shared_with: list[str] | None = None
     source_id: str = ""            # Fact ID or Entity ID
     target_id: str = ""            # Fact ID or Entity ID
     edge_type: EdgeType = EdgeType.ENTITY

--- a/src/superlocalmemory/storage/schema.py
+++ b/src/superlocalmemory/storage/schema.py
@@ -110,6 +110,8 @@ _SQL_MEMORIES: Final[str] = """
 CREATE TABLE IF NOT EXISTS memories (
     memory_id    TEXT PRIMARY KEY,
     profile_id   TEXT NOT NULL DEFAULT 'default',
+    scope        TEXT NOT NULL DEFAULT 'personal',
+    shared_with  TEXT,
     content      TEXT NOT NULL,
     session_id   TEXT NOT NULL DEFAULT '',
     speaker      TEXT NOT NULL DEFAULT '',
@@ -128,6 +130,10 @@ CREATE INDEX IF NOT EXISTS idx_memories_session
     ON memories (profile_id, session_id);
 CREATE INDEX IF NOT EXISTS idx_memories_created
     ON memories (created_at);
+CREATE INDEX IF NOT EXISTS idx_memories_scope
+    ON memories (scope);
+CREATE INDEX IF NOT EXISTS idx_memories_profile_scope
+    ON memories (profile_id, scope);
 """
 
 
@@ -140,6 +146,8 @@ CREATE TABLE IF NOT EXISTS atomic_facts (
     fact_id            TEXT PRIMARY KEY,
     memory_id          TEXT NOT NULL,
     profile_id         TEXT NOT NULL DEFAULT 'default',
+    scope              TEXT NOT NULL DEFAULT 'personal',
+    shared_with        TEXT,
     content            TEXT NOT NULL,
     fact_type          TEXT NOT NULL DEFAULT 'semantic'
                             CHECK (fact_type IN (
@@ -209,6 +217,10 @@ CREATE INDEX IF NOT EXISTS idx_facts_referenced_date
 CREATE INDEX IF NOT EXISTS idx_facts_interval
     ON atomic_facts (profile_id, interval_start, interval_end)
     WHERE interval_start IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_atomic_facts_scope
+    ON atomic_facts (scope);
+CREATE INDEX IF NOT EXISTS idx_atomic_facts_profile_scope
+    ON atomic_facts (profile_id, scope);
 """
 
 
@@ -287,6 +299,8 @@ _SQL_CANONICAL_ENTITIES: Final[str] = """
 CREATE TABLE IF NOT EXISTS canonical_entities (
     entity_id       TEXT PRIMARY KEY,
     profile_id      TEXT NOT NULL DEFAULT 'default',
+    scope           TEXT NOT NULL DEFAULT 'personal',
+    shared_with     TEXT,
     canonical_name  TEXT NOT NULL,
     entity_type     TEXT NOT NULL DEFAULT '',
     first_seen      TEXT NOT NULL DEFAULT (datetime('now')),
@@ -303,6 +317,10 @@ CREATE INDEX IF NOT EXISTS idx_entities_name_lower
     ON canonical_entities (profile_id, canonical_name COLLATE NOCASE);
 CREATE INDEX IF NOT EXISTS idx_entities_type
     ON canonical_entities (profile_id, entity_type);
+CREATE INDEX IF NOT EXISTS idx_canonical_entities_scope
+    ON canonical_entities (scope);
+CREATE INDEX IF NOT EXISTS idx_canonical_entities_profile_scope
+    ON canonical_entities (profile_id, scope);
 """
 
 
@@ -386,6 +404,8 @@ _SQL_TEMPORAL_EVENTS: Final[str] = """
 CREATE TABLE IF NOT EXISTS temporal_events (
     event_id         TEXT PRIMARY KEY,
     profile_id       TEXT NOT NULL DEFAULT 'default',
+    scope            TEXT NOT NULL DEFAULT 'personal',
+    shared_with      TEXT,
     entity_id        TEXT NOT NULL,
     fact_id          TEXT NOT NULL,
     observation_date TEXT,
@@ -409,6 +429,10 @@ CREATE INDEX IF NOT EXISTS idx_tevents_entity
 CREATE INDEX IF NOT EXISTS idx_tevents_date_range
     ON temporal_events (profile_id, referenced_date)
     WHERE referenced_date IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_temporal_events_scope
+    ON temporal_events (scope);
+CREATE INDEX IF NOT EXISTS idx_temporal_events_profile_scope
+    ON temporal_events (profile_id, scope);
 """
 
 
@@ -420,6 +444,8 @@ _SQL_GRAPH_EDGES: Final[str] = """
 CREATE TABLE IF NOT EXISTS graph_edges (
     edge_id     TEXT PRIMARY KEY,
     profile_id  TEXT NOT NULL DEFAULT 'default',
+    scope       TEXT NOT NULL DEFAULT 'personal',
+    shared_with TEXT,
     source_id   TEXT NOT NULL,
     target_id   TEXT NOT NULL,
     edge_type   TEXT NOT NULL DEFAULT 'entity'
@@ -444,6 +470,10 @@ CREATE INDEX IF NOT EXISTS idx_edges_type
     ON graph_edges (profile_id, edge_type);
 CREATE INDEX IF NOT EXISTS idx_edges_exists_check
     ON graph_edges (profile_id, source_id, target_id, edge_type);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_scope
+    ON graph_edges (scope);
+CREATE INDEX IF NOT EXISTS idx_graph_edges_profile_scope
+    ON graph_edges (profile_id, scope);
 """
 
 


### PR DESCRIPTION
## Summary

PR 1/3 of the multi-scope memory feature (RFC #20).

Adds `scope` and `shared_with` columns to 5 core tables for multi-scope memory support (personal / shared / global). Pure schema change — no retrieval or interface modifications.

### Changes

| File | Change |
|------|--------|
| `storage/schema.py` | Add `scope TEXT NOT NULL DEFAULT 'personal'` and `shared_with TEXT` to 5 tables + 10 composite indexes |
| `storage/models.py` | Add `scope` / `shared_with` fields to 5 dataclasses (MemoryRecord, AtomicFact, CanonicalEntity, GraphEdge, TemporalEvent) |
| `storage/migrations/M016_add_scope_support.py` | Deferred migration for existing databases |
| `storage/migration_runner.py` | Register M016 |

### Design
- Backward compatible: all existing data retains `scope='personal'`
- Follows upstream pattern: deferred migration like M006/M011/M013
- Tables: memories, atomic_facts, canonical_entities, graph_edges, temporal_events

### Dependencies
- **PR 2/3** (retrieval layer) builds on this
- **PR 3/3** (external interface) builds on PR 2/3

### Test Results
- **755 passed** on Ubuntu (all 3 Python versions)
- **75 passed** on macOS (all 3 Python versions)
- The 1 failure per platform (`test_cache_exact_replay_all_byte_identical` on Ubuntu, `test_vscode_user_dir_darwin` on macOS) are **pre-existing upstream issues** — reproducible on the upstream main branch CI.

Ref: #20