### PR TITLE
fix(_jl): NULL DB columns must reload as None when caller passes default=None

### DIFF
--- a/src/superlocalmemory/dynamics/fisher_langevin_coupling.py
+++ b/src/superlocalmemory/dynamics/fisher_langevin_coupling.py
@@ -111,6 +111,8 @@ class FisherLangevinCoupling:
             CouplingState with derived temperature, direction, and weight.
         """
         var_arr = np.asarray(fisher_variance, dtype=np.float64)
+        if var_arr.size == 0:
+            return CouplingState()
 
         # Step 1: Fisher confidence from variance
         # Low variance = high confidence (memory is well-characterized)
@@ -203,6 +205,8 @@ class FisherLangevinCoupling:
             return self._base_temp
 
         var_arr = np.asarray(fisher_variance, dtype=np.float64)
+        if var_arr.size == 0:
+            return self._base_temp
         avg_var = float(np.mean(np.clip(var_arr, 1e-8, None)))
         fisher_conf = min(1.0, 1.0 / (1.0 + avg_var) + min(access_count * 0.02, 0.2))
         return self._base_temp / (fisher_conf + self._epsilon)

--- a/src/superlocalmemory/storage/database.py
+++ b/src/superlocalmemory/storage/database.py
@@ -27,10 +27,16 @@ from superlocalmemory.storage.models import (
 
 logger = logging.getLogger(__name__)
 
-def _jl(raw: Any, default: Any = None) -> Any:
-    """JSON-load a value, returning *default* on None/empty."""
+_MISSING = object()
+
+def _jl(raw: Any, default: Any = _MISSING) -> Any:
+    """JSON-load a value, returning *default* on None/empty.
+
+    _jl(raw)       -> [] when raw is None/empty  (list fields)
+    _jl(raw, None) -> None when raw is None/empty (optional fields)
+    """
     if raw is None or raw == "":
-        return default if default is not None else []
+        return [] if default is _MISSING else default
     return json.loads(raw)
 
 def _jd(val: Any) -> str | None:

--- a/tests/test_dynamics/test_fisher_langevin_empty_variance.py
+++ b/tests/test_dynamics/test_fisher_langevin_empty_variance.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3
+
+"""Regression tests for FisherLangevinCoupling with empty fisher_variance.
+
+Background: when storage._jl(raw, None) erroneously returned [] for NULL DB
+columns, facts with no Fisher data reached apply_to_facts() with
+fisher_variance=[] instead of None. The `if f_var is None` guard never
+fired, np.mean was called on an empty array, and the daemon emitted:
+
+    numpy/_core/fromnumeric.py:3824: RuntimeWarning: Mean of empty slice
+    numpy/_core/_methods.py:142:    RuntimeWarning: invalid value encountered in scalar divide
+
+These tests lock down two invariants regardless of which layer leaked the
+empty array:
+
+  1. apply_to_facts() never emits RuntimeWarnings for None/empty variance.
+  2. The returned CouplingState has finite (non-NaN) numeric fields.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+import pytest
+
+from superlocalmemory.dynamics.fisher_langevin_coupling import (
+    CouplingState,
+    FisherLangevinCoupling,
+)
+
+
+@pytest.fixture
+def coupling() -> FisherLangevinCoupling:
+    return FisherLangevinCoupling()
+
+
+@pytest.mark.parametrize(
+    "fisher_variance",
+    [None, [], [0.0] * 0],
+    ids=["none", "empty-list", "zero-length-vector"],
+)
+def test_apply_to_facts_emits_no_runtime_warnings(
+    coupling: FisherLangevinCoupling, fisher_variance: object,
+) -> None:
+    facts = [{"fact_id": "f1", "fisher_variance": fisher_variance, "access_count": 0}]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        coupling.apply_to_facts(facts)
+    runtime = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert not runtime, f"unexpected RuntimeWarnings: {[str(w.message) for w in runtime]}"
+
+
+@pytest.mark.parametrize(
+    "fisher_variance", [None, []], ids=["none", "empty-list"],
+)
+def test_apply_to_facts_returns_finite_state(
+    coupling: FisherLangevinCoupling, fisher_variance: object,
+) -> None:
+    facts = [{"fact_id": "f1", "fisher_variance": fisher_variance, "access_count": 0}]
+    [state] = coupling.apply_to_facts(facts)
+    assert isinstance(state, CouplingState)
+    assert math.isfinite(state.fisher_confidence)
+    assert math.isfinite(state.langevin_temperature)
+    assert math.isfinite(state.lifecycle_weight)
+
+
+def test_compute_coupling_empty_variance_returns_default_state(
+    coupling: FisherLangevinCoupling,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        state = coupling.compute_coupling([], langevin_radius=0.5)
+    assert not [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert isinstance(state, CouplingState)
+
+
+def test_get_effective_temperature_empty_variance_falls_back_to_base(
+    coupling: FisherLangevinCoupling,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        temp = coupling.get_effective_temperature([])
+    assert not [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert math.isfinite(temp)
+    # Same path None takes — base_temp, not NaN.
+    assert temp == coupling.get_effective_temperature(None)

--- a/tests/test_storage/test_database.py
+++ b/tests/test_storage/test_database.py
@@ -635,3 +635,39 @@ class TestStoreFactIdempotent:
             (c,),
         )
         assert dict(rows[0])["c"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _jl sentinel — explicit default=None must round-trip as None, not []
+# ---------------------------------------------------------------------------
+
+class TestJlSentinel:
+    """Regression: _jl(raw, None) must return None for NULL/empty raw.
+
+    The pre-fix implementation collapsed "no default supplied" and "explicit
+    None default" into the same branch (`default if default is not None else
+    []`), so optional-list/optional-vector columns like fisher_variance,
+    embedding, langevin_position, shared_with loaded as [] instead of None,
+    defeating downstream `is None` guards.
+    """
+
+    def test_no_default_returns_empty_list_for_null(self) -> None:
+        from superlocalmemory.storage.database import _jl
+        assert _jl(None) == []
+        assert _jl("") == []
+
+    def test_explicit_none_default_returns_none_for_null(self) -> None:
+        from superlocalmemory.storage.database import _jl
+        assert _jl(None, None) is None
+        assert _jl("", None) is None
+
+    def test_explicit_other_default_preserved(self) -> None:
+        from superlocalmemory.storage.database import _jl
+        assert _jl(None, 0) == 0
+        assert _jl(None, {"k": "v"}) == {"k": "v"}
+
+    def test_non_null_raw_always_parsed(self) -> None:
+        from superlocalmemory.storage.database import _jl
+        assert _jl("[1, 2, 3]") == [1, 2, 3]
+        assert _jl("[1, 2, 3]", None) == [1, 2, 3]
+        assert _jl('{"a": 1}', None) == {"a": 1}


### PR DESCRIPTION
## Summary

`storage.database._jl(raw, default=None)` collapses two distinct caller intents into the same branch and unclear what the intention is:

```python
return default if default is not None else []
```

`_jl(raw, None)` and `_jl(raw)` therefore return the **same value** (`[]`) for NULL/empty raw, even though five callers in this very module explicitly pass `default=None` and expect `None` back:

```python
embedding         = _jl(d.get("embedding"), None)
fisher_mean       = _jl(d.get("fisher_mean"), None)
fisher_variance   = _jl(d.get("fisher_variance"), None)
langevin_position = _jl(d.get("langevin_position"), None)
shared_with       = _jl(d.get("shared_with"), None)   # added by bf5e947 (multi-scope)
```

All five have been silently receiving `[]` instead of `None`. The proposed fix uses a `_MISSING` sentinel so the two intents stay disambiguated.

## Most-visible symptom

When a fact has NULL `fisher_variance`, it reaches `FisherLangevinCoupling.apply_to_facts()` as `[]`. The `if f_var is None` guard never fires, so `compute_coupling([])` is called and `np.mean(np.clip([], 1e-8, None))` runs on an empty array. The scheduled maintenance pass then emits, every cycle:

```
numpy/_core/fromnumeric.py:3824: RuntimeWarning: Mean of empty slice
numpy/_core/_methods.py:142:    RuntimeWarning: invalid value encountered in scalar divide
```

Worse, `1/(1+NaN) = NaN` then poisons `fisher_confidence` and downstream `lifecycle_weight` / `langevin_temperature` for every affected fact in that batch.

## When the bug was likely introduced

`_jl` has had the buggy `default if default is not None else []` branch since it was first added in **`69fcbc8` ("SuperLocalMemory V3 — production-ready engine, dashboard, and compliance", 2026-03-16)**. The bug becomes increasingly problematic as more optional columns are added — most recently in `bf5e947` ("feat: expose multi-scope memory controls...") which added the `shared_with=_jl(..., None)` callsite. I don't see an upstream commit that ever fixed it.

## Minimal repro

```python
import warnings
from superlocalmemory.dynamics.fisher_langevin_coupling import FisherLangevinCoupling
from superlocalmemory.storage.database import _jl

# 1. _jl sentinel contract
assert _jl(None, None) is None         # FAILS pre-fix: returns []

# 2. apply_to_facts on the leaked empty array
with warnings.catch_warnings(record=True) as caught:
    warnings.simplefilter("always")
    FisherLangevinCoupling().apply_to_facts(
        [{"fact_id": "f", "fisher_variance": [], "access_count": 0}]
    )
runtime = [w for w in caught if issubclass(w.category, RuntimeWarning)]
assert not runtime, [str(w.message) for w in runtime]   # FAILS pre-fix with the warning pair above
```

Reproduces on my `upstream/main` (v3.6.16) cleanly. Stops reproducing with this patch applied.

## Changes

### `src/superlocalmemory/storage/database.py` (root cause)

Sentinel pattern so `default=None` is distinguishable from "no default":

```python
_MISSING = object()

def _jl(raw, default=_MISSING):
    """_jl(raw)       -> [] when raw is None/empty  (list fields)
       _jl(raw, None) -> None when raw is None/empty (optional fields)"""
    if raw is None or raw == "":
        return [] if default is _MISSING else default
    return json.loads(raw)
```

No call-site changes needed — the existing callers were already correct; only the implementation was potentially wrong.

### `src/superlocalmemory/dynamics/fisher_langevin_coupling.py` (defence-in-depth)

Adds `var_arr.size == 0` early-return in `compute_coupling` and `get_effective_temperature` so a future leak of `[]` from a different layer cannot resurrect the NaN path:

```python
var_arr = np.asarray(fisher_variance, dtype=np.float64)
if var_arr.size == 0:
    return CouplingState()             # / self._base_temp for get_effective_temperature
```

## Test additions

### `tests/test_storage/test_database.py::TestJlSentinel` (4 tests)
Pins the `_jl` contract:
- `_jl(None)` → `[]`  (and `_jl("")` → `[]`)
- `_jl(None, None)` → `None`  (and `_jl("", None)` → `None`)
- `_jl(None, 0)` / `_jl(None, {"k":"v"})` — explicit non-None default preserved
- non-null raw always parsed regardless of default

### `tests/test_dynamics/test_fisher_langevin_empty_variance.py` (7 tests)
Pins the no-warning + finite-output invariant for `None`, `[]`, and zero-length vector inputs, across `apply_to_facts`, `compute_coupling`, and `get_effective_temperature`.

Run with `-W error::RuntimeWarning` to catch any leaked numpy warning.

### Differential proof
- Against `upstream/main` (pre-fix): **6 of the 11 new tests fail**, pointing directly at the bug surface (`_jl` returning `[]` for `default=None`, and `Mean of empty slice` in `compute_coupling` / `get_effective_temperature`).
- With this PR applied: **all 11 pass**.

## Test plan

- [ ] `pytest tests/test_storage/test_database.py::TestJlSentinel -W error::RuntimeWarning`
- [ ] `pytest tests/test_dynamics/test_fisher_langevin_empty_variance.py -W error::RuntimeWarning`
- [ ] Existing test suite (no behavioural change for callers that don't pass `default=None`)