### PR TITLE
fix(hooks): resolve daemon port from port file, not hard-coded to :8765

### DIFF
--- a/src/superlocalmemory/hooks/hook_handlers.py
+++ b/src/superlocalmemory/hooks/hook_handlers.py
@@ -36,7 +36,32 @@ _LAST_CONSOLIDATION = os.path.join(
 )
 
 
-_DAEMON_URL = "http://127.0.0.1:8765"
+_DEFAULT_DAEMON_PORT = 8765
+
+
+def _daemon_url() -> str:
+    """Resolve the daemon base URL, preferring the per-user port file.
+
+    On a shared host each user runs their own daemon bound to a different
+    port; the active port is written to ``~/.superlocalmemory/daemon.port``
+    at startup. Reading it here keeps lifecycle hooks pointed at the
+    caller's own daemon instead of a hard-coded ``8765`` that may belong to
+    another user's instance. Falls back to the default port when the file is
+    absent or unreadable. Stdlib only — no SLM imports in the hot path.
+    """
+    port = _DEFAULT_DAEMON_PORT
+    try:
+        port_file = os.path.join(
+            os.path.expanduser("~"), ".superlocalmemory", "daemon.port",
+        )
+        with open(port_file) as fh:
+            port = int(fh.read().strip())
+    except Exception:
+        pass
+    return f"http://127.0.0.1:{port}"
+
+
+_DAEMON_URL = _daemon_url()
 
 
 def _daemon_post(path: str, body: dict, timeout: float = 3.0) -> bool:

--- a/src/superlocalmemory/hooks/post_tool_async_hook.py
+++ b/src/superlocalmemory/hooks/post_tool_async_hook.py
@@ -30,6 +30,24 @@ _ALLOWED_DAEMON_HOSTS: frozenset[str] = frozenset({
     "127.0.0.1", "localhost", "::1", "[::1]",
 })
 
+_DEFAULT_DAEMON_PORT = 8765
+
+
+def _port_file_url() -> str:
+    """Loopback daemon URL from the per-user port file (default 8765).
+
+    On a shared host each user runs their own daemon on a different port,
+    written to ``~/.superlocalmemory/daemon.port`` at startup. Falling back
+    to this instead of a hard-coded ``8765`` keeps the hook pointed at the
+    caller's own daemon. Stdlib only.
+    """
+    port = _DEFAULT_DAEMON_PORT
+    try:
+        port = int((Path.home() / ".superlocalmemory" / "daemon.port").read_text().strip())
+    except Exception:
+        pass
+    return f"http://127.0.0.1:{port}"
+
 
 def _sanitised_daemon_url() -> str:
     """Return the configured daemon URL only if it's loopback-scoped.
@@ -38,21 +56,21 @@ def _sanitised_daemon_url() -> str:
     shell profile) could set ``SLM_HOOK_DAEMON_URL`` to a remote host
     and exfiltrate the install token via the ``X-SLM-Hook-Token``
     header. We refuse any non-loopback URL and fall back to the local
-    daemon.
+    daemon (resolved via the per-user port file, not a hard-coded port).
     """
     raw = os.environ.get("SLM_HOOK_DAEMON_URL", "").strip()
     if not raw:
-        return "http://127.0.0.1:8765"
+        return _port_file_url()
     try:
         from urllib.parse import urlparse
         parsed = urlparse(raw)
     except Exception:  # pragma: no cover — urllib always importable
-        return "http://127.0.0.1:8765"
+        return _port_file_url()
     if parsed.scheme not in ("http", "https"):
-        return "http://127.0.0.1:8765"
+        return _port_file_url()
     host = (parsed.hostname or "").lower()
     if host not in _ALLOWED_DAEMON_HOSTS:
-        return "http://127.0.0.1:8765"
+        return _port_file_url()
     # Preserve the scheme + port (user may bind daemon on a non-default port).
     port = f":{parsed.port}" if parsed.port else ""
     return f"{parsed.scheme}://{host}{port}"

--- a/tests/test_hooks/test_daemon_port_discovery.py
+++ b/tests/test_hooks/test_daemon_port_discovery.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+
+"""Tests for per-user daemon port discovery in lifecycle hooks.
+
+On a shared host each user runs their own daemon on a different port
+(written to ``~/.superlocalmemory/daemon.port`` at startup). The hooks
+must read that file rather than hard-coding ``8765``, which on a
+multi-user machine may belong to another user's daemon.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from superlocalmemory.hooks import hook_handlers, post_tool_async_hook
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    slm_home = tmp_path / ".superlocalmemory"
+    slm_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr("os.path.expanduser", lambda p: p.replace("~", str(tmp_path), 1))
+    return slm_home
+
+
+# ---------------------------------------------------------------------------
+# hook_handlers._daemon_url
+# ---------------------------------------------------------------------------
+
+def test_hook_handlers_reads_port_file(home: Path) -> None:
+    (home / "daemon.port").write_text("8766")
+    assert hook_handlers._daemon_url() == "http://127.0.0.1:8766"
+
+
+def test_hook_handlers_defaults_when_no_port_file(home: Path) -> None:
+    assert hook_handlers._daemon_url() == "http://127.0.0.1:8765"
+
+
+def test_hook_handlers_defaults_on_garbage_port_file(home: Path) -> None:
+    (home / "daemon.port").write_text("not-a-number")
+    assert hook_handlers._daemon_url() == "http://127.0.0.1:8765"
+
+
+# ---------------------------------------------------------------------------
+# post_tool_async_hook._port_file_url and fallback path
+# ---------------------------------------------------------------------------
+
+def test_async_hook_reads_port_file(home: Path) -> None:
+    (home / "daemon.port").write_text("8766")
+    assert post_tool_async_hook._port_file_url() == "http://127.0.0.1:8766"
+
+
+def test_async_hook_defaults_when_no_port_file(home: Path) -> None:
+    assert post_tool_async_hook._port_file_url() == "http://127.0.0.1:8765"
+
+
+def test_async_hook_env_unset_falls_back_to_port_file(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SLM_HOOK_DAEMON_URL", raising=False)
+    (home / "daemon.port").write_text("8766")
+    assert post_tool_async_hook._sanitised_daemon_url() == "http://127.0.0.1:8766"
+
+
+def test_async_hook_non_loopback_env_falls_back_to_port_file(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # S8-SEC-02: a hostile non-loopback URL must be refused — and the
+    # fallback must still honour the per-user port, not hard-coded 8765.
+    monkeypatch.setenv("SLM_HOOK_DAEMON_URL", "http://evil.example.com:9999")
+    (home / "daemon.port").write_text("8766")
+    assert post_tool_async_hook._sanitised_daemon_url() == "http://127.0.0.1:8766"
+
+
+def test_async_hook_loopback_env_with_port_is_preserved(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SLM_HOOK_DAEMON_URL", "http://127.0.0.1:8888")
+    assert post_tool_async_hook._sanitised_daemon_url() == "http://127.0.0.1:8888"


### PR DESCRIPTION
## Problem

`hook_handlers.py` and `post_tool_async_hook.py` both hard-code `http://127.0.0.1:8765` as the daemon URL. On a shared host where e.g. multiple users each run their own daemon on a distinct port, a non-default user's lifecycle hooks POST to 8765 — which under fast user switching may belong to another user's daemon — silently dropping memory captures or cross-contaminating a different instance's DB.

## Fix

Propose that both files call a small helper that reads `~/.superlocalmemory/daemon.port` (already written by the daemon at startup, already read by `cli/daemon.py` and `mcp/tools_mesh.py`), falling back to 8765 only when the file is absent or unreadable. Stdlib only — no new imports in the hot path.

Precedence in `post_tool_async_hook` (S8-SEC-02 guard preserved):
1. `SLM_HOOK_DAEMON_URL` env var — if set **and** loopback
2. `~/.superlocalmemory/daemon.port`
3. Hard-coded fallback `8765`

## Changes

- `src/superlocalmemory/hooks/hook_handlers.py` — replace `_DAEMON_URL` constant with `_daemon_url()` helper
- `src/superlocalmemory/hooks/post_tool_async_hook.py` — add `_port_file_url()` helper, replace four hard-coded fallback returns
- `tests/test_hooks/test_daemon_port_discovery.py` — 8 new tests (port file read, missing file, garbage content, env-unset fallback, hostile non-loopback env rejected, explicit loopback env preserved)