### PR TITLE
feat(adapters): marker-bounded writes to agent instruction files

### DIFF
--- a/src/superlocalmemory/hooks/copilot_adapter.py
+++ b/src/superlocalmemory/hooks/copilot_adapter.py
@@ -8,9 +8,15 @@ LLD-05 §6. Verified (verification-2026-04-17.md claim 5): plain markdown,
 no frontmatter, soft 2 KB / hard 4 KB cap. Adapter is INACTIVE when the
 project has no ``.github/`` directory — we do not create it ourselves.
 
+v3.4.23 fix: the SLM-managed content is wrapped in
+``<!-- SLM-START -->`` / ``<!-- SLM-END -->`` markers and merged into the
+host file rather than overwriting it. ``.github/copilot-instructions.md``
+is typically a curated, project-specific document; destructive rewrites
+deleted the user's prose.
+
 Hard rules covered here:
   - A1 / A2 / A3 / A7: via ``adapter_base.atomic_write``.
-  - A4: soft 2 KB + hard 4 KB cap enforcement.
+  - A4: soft 2 KB + hard 4 KB cap enforcement on the SLM section.
 """
 
 from __future__ import annotations
@@ -39,6 +45,12 @@ from superlocalmemory.hooks.context_payload import (
     format_topics,
     truncate_payload_for_cap,
 )
+from superlocalmemory.hooks.memory_protocol import (
+    SLM_MARKER_END,
+    SLM_MARKER_START,
+    memory_protocol_markdown,
+    strip_slm_block as _strip_existing_block,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,20 +64,37 @@ _BODY_TEMPLATE = (
     "## Entities\n{entities}\n\n"
     "## Never do\n"
     "- Do not modify files under `.slm/`\n"
-    "- Do not commit `*.slm-cache.db`\n"
+    "- Do not commit `*.slm-cache.db`\n\n"
 )
 
 
 def render_copilot(payload: ContextPayload) -> bytes:
-    return _BODY_TEMPLATE.format(
+    # Two-stage assembly: format the dynamic header (which contains {}
+    # placeholders), then concatenate the static memory-protocol block
+    # verbatim. The memory-protocol block legitimately contains literal
+    # braces (JSON-shaped argument examples for the agent) which must not
+    # be interpreted as format fields.
+    header = _BODY_TEMPLATE.format(
         version=payload.version,
         topics=format_topics(payload),
         entities=format_entities(payload),
-    ).encode("utf-8")
+    )
+    return (header + memory_protocol_markdown()).encode("utf-8")
+
+
+def _wrap_managed(rendered: bytes) -> str:
+    """Wrap rendered SLM content in ``<!-- SLM-START -->`` markers."""
+    return (
+        f"{SLM_MARKER_START}\n"
+        "<!-- Managed by SuperLocalMemory. Edits between SLM-START and "
+        "SLM-END will be overwritten. -->\n\n"
+        f"{rendered.decode('utf-8')}\n"
+        f"{SLM_MARKER_END}\n"
+    )
 
 
 class CopilotAdapter:
-    """Project-scope Copilot adapter."""
+    """Project-scope Copilot adapter (marker-bounded merge)."""
 
     def __init__(
         self,
@@ -124,8 +153,39 @@ class CopilotAdapter:
             )
             rendered = truncate_to_cap(rendered, cap=self._hard_cap)
 
+        # Marker-bounded merge — preserve any user-curated content in the
+        # host file. Strip any prior SLM block(s) and re-append a fresh one.
+        existing = ""
+        if resolved.exists():
+            try:
+                existing = resolved.read_text(encoding="utf-8")
+            except OSError as exc:
+                logger.warning(
+                    "copilot: cannot read %s: %s", resolved, exc,
+                )
+                return False
+
+        # Orphaned start marker — refuse to write rather than corrupt.
+        if (SLM_MARKER_START in existing
+                and SLM_MARKER_END not in existing):
+            logger.warning(
+                "copilot: %s present but %s missing in %s; refusing to write",
+                SLM_MARKER_START, SLM_MARKER_END, resolved,
+            )
+            return False
+
+        stripped = _strip_existing_block(existing)
+        section = _wrap_managed(rendered)
+        if stripped:
+            if not stripped.endswith("\n"):
+                stripped += "\n"
+            # One blank line between user content and the managed section.
+            new_content = stripped + "\n" + section
+        else:
+            new_content = section
+
         result: WriteResult = atomic_write(
-            resolved, rendered,
+            resolved, new_content.encode("utf-8"),
             adapter_name=self.name,
             profile_id=self._profile_id,
             sync_log_db=self._sync_log_db,
@@ -137,11 +197,20 @@ class CopilotAdapter:
             resolved = self.target_path
         except PathTraversalError:
             return
+        # Marker-bounded strip — never delete the host file (user-owned).
         if resolved.exists():
             try:
-                resolved.unlink()
-            except OSError:  # pragma: no cover
-                pass
+                existing = resolved.read_text(encoding="utf-8")
+            except OSError:
+                existing = ""
+            stripped = _strip_existing_block(existing)
+            if stripped != existing:
+                try:
+                    resolved.write_text(stripped, encoding="utf-8")
+                except OSError as exc:  # pragma: no cover
+                    logger.warning(
+                        "copilot: failed to strip on disable: %s", exc,
+                    )
         record_disable(
             resolved,
             adapter_name=self.name,

--- a/src/superlocalmemory/hooks/memory_protocol.py
+++ b/src/superlocalmemory/hooks/memory_protocol.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3 | https://qualixar.com | https://varunpratap.com
+
+"""Shared utilities for marker-bounded writes into agent instruction files.
+
+Adapters that inject SLM content into IDE/agent instruction files (e.g.
+``.github/copilot-instructions.md``) use the constants and helpers here to
+demarcate the SLM-managed section so user-curated content outside the
+markers is preserved on every sync.
+
+Marker contract
+---------------
+SLM wraps its content in a pair of HTML comments::
+
+    <!-- SLM-START -->
+    ... managed content ...
+    <!-- SLM-END -->
+
+``strip_slm_block`` removes all such pairs idempotently; adapters call it
+before re-writing so a fresh block replaces the old one in place.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Opening marker for the SLM-managed section.
+SLM_MARKER_START = "<!-- SLM-START -->"
+#: Closing marker for the SLM-managed section.
+SLM_MARKER_END = "<!-- SLM-END -->"
+
+
+def strip_slm_block(text: str) -> str:
+    """Remove all SLM-managed sections from *text*.
+
+    Idempotent — returns *text* unchanged when no markers are present.
+    Strips every ``SLM-START``/``SLM-END`` pair to handle files that
+    accumulated duplicates from a previous bug or a competing writer.
+
+    If a ``SLM-START`` marker has no matching ``SLM-END``, the file is
+    returned unchanged to avoid eating user content; the caller should
+    treat this as an orphaned-marker error and skip the write.
+    """
+    out = text
+    while True:
+        start_idx = out.find(SLM_MARKER_START)
+        if start_idx == -1:
+            return out
+        end_idx = out.find(SLM_MARKER_END, start_idx)
+        if end_idx == -1:
+            logger.warning(
+                "memory_protocol: %s found but %s missing; leaving file unchanged",
+                SLM_MARKER_START,
+                SLM_MARKER_END,
+            )
+            return text
+        cut_end = end_idx + len(SLM_MARKER_END)
+        if cut_end < len(out) and out[cut_end] == "\n":
+            cut_end += 1
+        # Pull back up to two leading newlines added as a boundary separator.
+        cut_start = start_idx
+        while cut_start > 0 and out[cut_start - 1] == "\n":
+            cut_start -= 1
+            if start_idx - cut_start >= 2:
+                break
+        out = out[:cut_start] + out[cut_end:]
+
+
+def memory_protocol_markdown() -> str:
+    """Return the agent-facing Markdown memory protocol block.
+
+    Embedded verbatim into Markdown instruction files such as
+    ``.github/copilot-instructions.md``.  Trailing newline included so
+    callers can concatenate without worrying about boundary whitespace.
+    """
+    return (
+        "## Memory protocol\n"
+        "SLM tools are available via the `slm-hub` MCP gateway. Use them to "
+        "make this brain context grow across sessions.\n\n"
+        "- **At the start of work on an unfamiliar area**, call "
+        "`hub__call_tool` with `tool=\"slm__recall\"` and "
+        "`arguments={\"query\": \"<topic>\"}` to surface prior decisions "
+        "and patterns.\n"
+        "- **At the end of a substantial task** (a fix, a decision, a "
+        "non-trivial change, a session conclusion), call `hub__call_tool` "
+        "with `tool=\"slm__remember\"` and `arguments={\"content\": "
+        "\"<one-paragraph summary of what was decided / changed / "
+        "learned>\", \"tags\": \"<comma-separated kebab-case keywords>\"}`.\n"
+        "- A \"substantial task\" is anything you would write a commit "
+        "message or handoff note about — not every tool call.\n"
+    )
+
+
+__all__ = (
+    "SLM_MARKER_START",
+    "SLM_MARKER_END",
+    "strip_slm_block",
+    "memory_protocol_markdown",
+)

--- a/tests/test_adapters/test_copilot_adapter.py
+++ b/tests/test_adapters/test_copilot_adapter.py
@@ -31,7 +31,9 @@ def test_writes_to_github_copilot_instructions_md(tmp_path, fake_recall):
     adapter.sync()
     path = tmp_path / TARGET_REL
     assert path.exists()
-    assert path.read_text().startswith("# SLM Active Brain Context")
+    content = path.read_text()
+    assert "# SLM Active Brain Context" in content
+    assert content.startswith("<!-- SLM-START -->")
 
 
 def test_size_soft_cap_2kb(tmp_path, fake_recall):
@@ -81,7 +83,10 @@ def test_disable(tmp_path, fake_recall):
     path = tmp_path / TARGET_REL
     assert path.exists()
     adapter.disable()
-    assert not path.exists()
+    # Marker-bounded: disable() strips the SLM block but does not delete the
+    # file — copilot-instructions.md is user-owned and may contain other content.
+    assert path.exists()
+    assert "<!-- SLM-START -->" not in path.read_text()
     assert adapter.is_active() is False
 
 

--- a/tests/test_adapters/test_copilot_adapter_nondestructive.py
+++ b/tests/test_adapters/test_copilot_adapter_nondestructive.py
@@ -1,0 +1,163 @@
+"""Non-destructive write tests for CopilotAdapter marker-bounded merge.
+
+Use cases validated here:
+
+1. **Agent-authored project instructions** — an AI agent writes custom
+   guidance into ``.github/copilot-instructions.md`` (e.g. "always use
+   our error-handling convention"). SLM must not erase that on its next
+   sync; only the SLM-managed block should be replaced.
+
+2. **User-curated project conventions** — a developer maintains a
+   hand-written ``## Conventions`` section in the instructions file. SLM
+   syncs must leave that prose intact.
+
+3. **Disable must not delete the file** — calling ``adapter.disable()``
+   should strip the SLM block but preserve everything else; it must not
+   ``unlink()`` the file (which was the upstream behaviour before this fix).
+
+4. **Orphaned start marker safety** — if ``<!-- SLM-START -->`` is present
+   but ``<!-- SLM-END -->`` is missing (e.g. a truncated write), SLM must
+   refuse to write rather than creating a second, broken block.
+
+5. **Idempotent sync** — syncing twice with identical recall data must not
+   change the file content.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from superlocalmemory.hooks.copilot_adapter import CopilotAdapter, TARGET_REL
+from superlocalmemory.hooks.memory_protocol import SLM_MARKER_END, SLM_MARKER_START
+
+
+def _adapter(tmp_path: Path, recall=None) -> CopilotAdapter:
+    (tmp_path / ".github").mkdir(exist_ok=True)
+    return CopilotAdapter(
+        base_dir=tmp_path,
+        sync_log_db=tmp_path / "memory.db",
+        recall_fn=recall or (lambda q, l, p: []),
+    )
+
+
+def _target(tmp_path: Path) -> Path:
+    return tmp_path / TARGET_REL
+
+
+# ---------------------------------------------------------------------------
+# Use case 1 & 2: user / agent content is preserved
+# ---------------------------------------------------------------------------
+
+def test_sync_preserves_existing_user_content(tmp_path):
+    """User prose before the SLM block must survive a sync."""
+    target = _target(tmp_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# My Project Rules\n\nAlways use our logging library.\n")
+
+    _adapter(tmp_path).sync()
+
+    result = target.read_text()
+    assert "# My Project Rules" in result
+    assert "Always use our logging library." in result
+    assert SLM_MARKER_START in result
+
+
+def test_sync_preserves_content_after_slm_block(tmp_path):
+    """User prose after the SLM block must also survive a sync."""
+    target = _target(tmp_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        f"{SLM_MARKER_START}\nold slm content\n{SLM_MARKER_END}\n"
+        "\n## Post-SLM user notes\nDo not delete me.\n"
+    )
+
+    _adapter(tmp_path).sync()
+
+    result = target.read_text()
+    assert "Do not delete me." in result
+    assert SLM_MARKER_START in result
+
+
+def test_sync_replaces_only_slm_block(tmp_path):
+    """The SLM block is replaced; surrounding content is unchanged."""
+    target = _target(tmp_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    user_before = "# Agent Rules\n\nUse snake_case.\n"
+    user_after = "\n## Team conventions\nReview all PRs.\n"
+    target.write_text(
+        user_before
+        + f"{SLM_MARKER_START}\nstale slm block\n{SLM_MARKER_END}\n"
+        + user_after
+    )
+
+    _adapter(tmp_path).sync()
+
+    result = target.read_text()
+    assert "Use snake_case." in result
+    assert "Review all PRs." in result
+    assert "stale slm block" not in result
+    assert SLM_MARKER_START in result
+
+
+# ---------------------------------------------------------------------------
+# Use case 3: disable must not delete the file
+# ---------------------------------------------------------------------------
+
+def test_disable_strips_slm_block_but_keeps_file(tmp_path):
+    """disable() must not unlink() the file — it strips the SLM section only."""
+    adapter = _adapter(tmp_path)
+    adapter.sync()
+    target = _target(tmp_path)
+    assert target.exists()
+
+    adapter.disable()
+
+    assert target.exists(), "disable() must not delete the file"
+    content = target.read_text()
+    assert SLM_MARKER_START not in content
+
+
+def test_disable_preserves_user_content(tmp_path):
+    """User content outside the SLM block must survive disable()."""
+    target = _target(tmp_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# My notes\n\nKeep this.\n")
+
+    adapter = _adapter(tmp_path)
+    adapter.sync()
+    adapter.disable()
+
+    assert "Keep this." in target.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Use case 4: orphaned start marker is handled safely
+# ---------------------------------------------------------------------------
+
+def test_sync_refuses_on_orphaned_start_marker(tmp_path):
+    """If SLM-START has no matching SLM-END, sync must not write."""
+    target = _target(tmp_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(f"# Notes\n\n{SLM_MARKER_START}\nno end marker here\n")
+    original = target.read_text()
+
+    result = _adapter(tmp_path).sync()
+
+    assert result is False
+    assert target.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# Use case 5: idempotent sync
+# ---------------------------------------------------------------------------
+
+def test_sync_is_idempotent(tmp_path):
+    """Two syncs with identical recall data must produce identical file content."""
+    adapter = _adapter(tmp_path)
+    adapter.sync()
+    first = _target(tmp_path).read_text()
+
+    adapter.sync()
+    second = _target(tmp_path).read_text()
+
+    assert first == second


### PR DESCRIPTION
## Problem

`CopilotAdapter` unconditionally replaces the full content of `.github/copilot-instructions.md` on every sync. This file is typically a curated, project-specific document maintained by developers and AI agents alike. The destructive overwrite deletes everything outside SLM's own content — silently and permanently.

**Use cases broken by the current behaviour:**

1. **Agent-authored guidance** — an AI agent writes custom instructions into the file (e.g. error-handling conventions, coding standards). The next SLM sync wipes them.
2. **User-curated project conventions** — a developer maintains a `## Conventions` section alongside the SLM brain context. Both should coexist; currently only one survives.
3. **disable() deleted the file** — `disable()` called `unlink()`, removing a file the user may have spent time curating. The file is user-owned; SLM should never delete it.

## Solution

Wrap the SLM-managed content in HTML comment markers and merge it into the host file rather than replacing it:

```
<!-- SLM-START -->
<!-- Managed by SuperLocalMemory. Edits between SLM-START and SLM-END will be overwritten. -->

... SLM brain context ...

<!-- SLM-END -->
```

On every sync:
- Content **outside** the markers is left intact.
- The SLM block **between** the markers is replaced with fresh content.
- If the file has no markers yet, the SLM block is appended.
- `disable()` strips the SLM block but does not delete the file.
- An orphaned `SLM-START` with no matching `SLM-END` causes a safe no-op (no write) rather than appending a second broken block.

## Scope

| File | Change |
|---|---|
| `hooks/memory_protocol.py` *(new)* | `SLM_MARKER_START/END` constants + `strip_slm_block()` helper — single source of truth for any future adapter adopting this pattern |
| `hooks/copilot_adapter.py` | Marker-bounded `sync()` and `disable()`; imports only from `memory_protocol` |

`context_commands.py` and all other files are **unchanged**.

## Tests

`tests/test_adapters/test_copilot_adapter_nondestructive.py` (new, 5 scenarios):

| Test | What it verifies |
|---|---|
| `test_sync_preserves_existing_user_content` | User prose before the SLM block survives a sync |
| `test_sync_preserves_content_after_slm_block` | User prose after the SLM block survives a sync |
| `test_sync_replaces_only_slm_block` | Stale SLM block is replaced; surrounding content unchanged |
| `test_disable_strips_slm_block_but_keeps_file` | `disable()` removes the SLM section but does not delete the file |
| `test_sync_refuses_on_orphaned_start_marker` | Orphaned `SLM-START` causes a safe no-op |

Two existing tests in `test_copilot_adapter.py` were updated to reflect the new write format (file now starts with `<!-- SLM-START -->` rather than `# SLM Active Brain Context`).