### PR TITLE
fix(hooks): re-hash on-disk file before accepting a durable skip in atomic_write

### DIFF
--- a/src/superlocalmemory/hooks/adapter_base.py
+++ b/src/superlocalmemory/hooks/adapter_base.py
@@ -217,9 +217,16 @@ def atomic_write(
     prev = sync_log_last_content_sha256(sync_log_db, adapter_name, target_sha)
 
     if prev == new_hash and resolved_path.exists():
-        # Durable skip — no write, no new sync-log row (the prior row still
-        # reflects on-disk truth).
-        return WriteResult(wrote=False, bytes_written=0, content_sha256=new_hash)
+        # Durable skip only if the on-disk content also matches the new hash.
+        # The sync-log row alone is not authoritative: the file may have been
+        # mutated out-of-band (e.g. ``git restore``, manual edit) since the
+        # last sync. Re-hash the file and re-write if it diverges.
+        try:
+            disk_hash = hashlib.sha256(resolved_path.read_bytes()).hexdigest()
+        except OSError:
+            disk_hash = None
+        if disk_hash == new_hash:
+            return WriteResult(wrote=False, bytes_written=0, content_sha256=new_hash)
 
     resolved_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = resolved_path.with_suffix(resolved_path.suffix + ".slm-tmp")

--- a/tests/test_adapters/test_extra_coverage.py
+++ b/tests/test_adapters/test_extra_coverage.py
@@ -96,6 +96,37 @@ def test_atomic_write_rewrites_on_content_change(tmp_path):
     assert target.read_bytes() == b"second"
 
 
+def test_atomic_write_rewrites_after_out_of_band_mutation(tmp_path):
+    """Sync-log skip must not fire when the file was mutated out-of-band.
+
+    Regression guard: git restore / manual edit changes the on-disk content
+    after a successful sync. Without on-disk re-hash, the next sync would
+    compare new_hash against the stale sync-log row (which matches) and skip
+    the write — leaving the file in its diverged state forever.
+    """
+    target = tmp_path / "f.txt"
+    content = b"slm-managed content"
+    db = tmp_path / "m.db"
+
+    r1 = atomic_write(target, content, adapter_name="test", profile_id="p",
+                      sync_log_db=db)
+    assert r1.wrote
+
+    # Second sync — content unchanged, durable skip should fire.
+    r2 = atomic_write(target, content, adapter_name="test", profile_id="p",
+                      sync_log_db=db)
+    assert not r2.wrote
+
+    # Out-of-band mutation (simulates ``git restore`` or manual edit).
+    target.write_bytes(b"user has edited this file manually")
+
+    # Third sync — sync-log says skip, but on-disk truth differs. Must re-write.
+    r3 = atomic_write(target, content, adapter_name="test", profile_id="p",
+                      sync_log_db=db)
+    assert r3.wrote
+    assert target.read_bytes() == content
+
+
 # ---------------------------------------------------------------------------
 # antigravity
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`atomic_write` uses a sync-log to skip redundant writes: when the hash of the new content matches the last recorded write, the function returns early with `wrote=False`. This is correct for the normal case.

But the sync-log only records what SLM *wrote* — it cannot know if the file was mutated out-of-band since the last sync. If the on-disk content diverges (e.g. `git restore`, a manual edit, an IDE reformat), the sync-log row still matches the new hash. The next sync skips the write and the file is left in its diverged state permanently — until a content change forces a fresh write.

This was surfaced against the `copilot_project` adapter: after `git restore .github/copilot-instructions.md`, SLM stopped re-syncing the file.

## Fix

Read and re-hash the file before accepting a skip. Only skip when **both** the sync-log and the on-disk content agree with the new hash. The extra read is bounded by the 2–4 KB cap on adapter files and occurs only on the cache-hit path (i.e., when content is unchanged between syncs — the most common case).

```python
if prev == new_hash and resolved_path.exists():
    try:
        disk_hash = hashlib.sha256(resolved_path.read_bytes()).hexdigest()
    except OSError:
        disk_hash = None
    if disk_hash == new_hash:
        return WriteResult(wrote=False, bytes_written=0, content_sha256=new_hash)
    # fall through → re-write
```

## Test

Added `test_atomic_write_rewrites_after_out_of_band_mutation` in `tests/test_adapters/test_extra_coverage.py`. The test:

1. Syncs content → `wrote=True`
2. Re-syncs same content → `wrote=False` (durable skip fires correctly)
3. Mutates the file out-of-band (simulates `git restore`)
4. Re-syncs same content → `wrote=True` (must recover)
