### PR TITLE
fix(workers): restore parallel OpenMP in embedding and reranker subprocess workers

### DIFF
--- a/src/superlocalmemory/core/embeddings.py
+++ b/src/superlocalmemory/core/embeddings.py
@@ -473,6 +473,11 @@ class EmbeddingService:
                 "TOKENIZERS_PARALLELISM": "false",
                 "TORCH_DEVICE": "cpu",
                 "ORT_DISABLE_COREML": "1",
+                # Restore parallel OpenMP. The package caps OMP_NUM_THREADS
+                # globally to avoid a torch+lightgbm libomp SIGSEGV in the
+                # main process. This worker loads torch but never lightgbm,
+                # so there is no collision risk and full parallelism is safe.
+                "OMP_NUM_THREADS": str(os.cpu_count() or 4),
             }
             from superlocalmemory.core.platform_utils import popen_platform_kwargs
             self._worker_proc = subprocess.Popen(

--- a/src/superlocalmemory/retrieval/reranker.py
+++ b/src/superlocalmemory/retrieval/reranker.py
@@ -197,6 +197,11 @@ class CrossEncoderReranker:
                 "TOKENIZERS_PARALLELISM": "false",
                 "TORCH_DEVICE": "cpu",
                 "ORT_DISABLE_COREML": "1",
+                # Restore parallel OpenMP. The package caps OMP_NUM_THREADS
+                # globally to avoid a torch+lightgbm libomp SIGSEGV in the
+                # main process. This worker loads torch but never lightgbm,
+                # so there is no collision risk and full parallelism is safe.
+                "OMP_NUM_THREADS": str(os.cpu_count() or 4),
             }
             from superlocalmemory.core.platform_utils import popen_platform_kwargs
             self._worker_proc = subprocess.Popen(


### PR DESCRIPTION
## Background

PR #27 isolated LightGBM training in a subprocess to prevent a SIGSEGV caused by torch + lightgbm loading separate libomp copies in the same process. As part of that mitigation, `__init__.py` sets `OMP_NUM_THREADS` at process startup to cap OpenMP parallelism before torch imports.

This is necessary for the main daemon process, which co-loads both libraries.

## Problem

The embedding service (`core/embeddings.py`) and the cross-encoder reranker (`retrieval/reranker.py`) both run in **subprocess workers** spawned via `subprocess.Popen`. These workers are separate processes that load PyTorch but **never load LightGBM**. There is no risk of a dual-libomp collision in their address space.

Despite this, both workers inherit the parent's `OMP_NUM_THREADS` cap. On a typical M2 Mac (8 performance cores), embedding and reranking are limited to ≤25% of available CPU. These operations are on the **recall hot path** — every `slm__recall` MCP call drives at least one embedding and (in v2 ranking mode) a rerank pass. The cap compounds latency for IDE integrations that invoke recall during coding sessions.

## Proposed Fix

Add `"OMP_NUM_THREADS": str(os.cpu_count() or 4)` to each worker's subprocess `env=` dict. The env override applies only to the child process and has no effect on the main daemon.

Both files already import `os`.

## Impact

- Main daemon: no change, existing OMP cap applies as before
- Embedding worker: runs with full CPU count (e.g. 8 on M2)
- Reranker worker: runs with full CPU count
- No new dependencies
- No behaviour change for correctness — only throughput improvement