### PR TITLE
fix(llm): anthropic provider must respect api_base when set

### DIFF
--- a/src/superlocalmemory/llm/backbone.py
+++ b/src/superlocalmemory/llm/backbone.py
@@ -295,7 +295,14 @@ class LLMBackbone:
         }
         if system:
             payload["system"] = system
-        return _ANTHROPIC_URL, headers, payload
+        # Respect custom base_url (e.g. Anthropic-compatible proxy).
+        # Append /v1/messages to the root URL, mirroring how _build_openai
+        # handles api_base. Falls back to the official Anthropic endpoint.
+        url = (
+            self._base_url.rstrip("/") + "/v1/messages"
+            if self._base_url else _ANTHROPIC_URL
+        )
+        return url, headers, payload
 
     def _build_azure(
         self, prompt: str, system: str, max_tokens: int, temperature: float,

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -38,6 +38,31 @@ def test_anthropic_provider_init():
     assert backbone.is_available()
 
 
+def test_anthropic_provider_respects_api_base():
+    """api_base must be used as the request URL for the anthropic provider.
+
+    Regression guard: _base_url is stored from config.api_base in __init__
+    but _build_anthropic previously ignored it, always returning
+    _ANTHROPIC_URL. This test verifies the built URL uses api_base when set.
+    """
+    proxy = "https://my-proxy.example.com"
+    config = LLMConfig(
+        provider="anthropic", model="claude-sonnet-4-6",
+        api_key="sk-ant-test", api_base=proxy,
+    )
+    backbone = LLMBackbone(config)
+    url, _, _ = backbone._build_anthropic("hi", "", 100, 0.0)
+    assert url == proxy + "/v1/messages"
+
+
+def test_anthropic_provider_default_url_without_api_base():
+    from superlocalmemory.llm.backbone import _ANTHROPIC_URL
+    config = LLMConfig(provider="anthropic", model="claude-sonnet-4-6", api_key="sk-ant-test")
+    backbone = LLMBackbone(config)
+    url, _, _ = backbone._build_anthropic("hi", "", 100, 0.0)
+    assert url == _ANTHROPIC_URL
+
+
 def test_ollama_provider_no_key_needed():
     config = LLMConfig(provider="ollama", model="llama3.2")
     backbone = LLMBackbone(config)


### PR DESCRIPTION
## Problem

`LLMBackbone.__init__` assigns `self._base_url = config.api_base` for the `"anthropic"` provider (via the `elif self._provider:` branch). The value is stored correctly. However, `_build_anthropic()` always returns `_ANTHROPIC_URL` — the stored `_base_url` is being silently discarded.

This means `LLMConfig(provider="anthropic", api_base="https://my-proxy.example.com")` has no effect: all requests still go to `https://api.anthropic.com/v1/messages`.

The other builders do not have this bug:
- `_build_openai`: `url = self._base_url or _OPENAI_URL` + path appending
- `_build_azure`: requires `_base_url`, raises if absent

## Fix

In `_build_anthropic`, use `_base_url` when set, appending `/v1/messages` to the root URL. Falls back to `_ANTHROPIC_URL` when no `api_base` is configured. Mirrors the existing OpenAI pattern.

```python
url = (
    self._base_url.rstrip("/") + "/v1/messages"
    if self._base_url else _ANTHROPIC_URL
)
return url, headers, payload
```

## Tests

Added two tests to `tests/test_llm_provider.py`:
- `test_anthropic_provider_respects_api_base`: verifies the proxy URL is used when `api_base` is set
- `test_anthropic_provider_default_url_without_api_base`: verifies `_ANTHROPIC_URL` is unchanged when no `api_base` is configured
