### PR TITLE
fix(server): resolve SLM data dir via env vars, not hardcoded path

### DIFF
--- a/src/superlocalmemory/server/routes/helpers.py
+++ b/src/superlocalmemory/server/routes/helpers.py
@@ -11,6 +11,7 @@ shared lazy engine accessor used by every engine-dependent route.
 import logging
 import re
 import json
+import os
 import sqlite3
 import threading
 import time
@@ -66,11 +67,90 @@ def _get_version() -> str:
 
 SLM_VERSION = _get_version()
 
-# V3 paths (migrated from ~/.claude-memory to ~/.superlocalmemory)
-MEMORY_DIR = Path.home() / ".superlocalmemory"
-DB_PATH = MEMORY_DIR / "memory.db"
+
+def _resolve_slm_home() -> Path:
+    """Resolve the SLM data dir the SAME way the CLI does.
+
+    The CLI honours ``SLM_DATA_DIR`` → ``SL_MEMORY_PATH`` → ``SLM_HOME``
+    → ``~/.superlocalmemory`` (see ``cli/_lazy_init.py:slm_home``). The
+    dashboard previously hardcoded ``Path.home() / ".superlocalmemory"``,
+    so when a user pointed the CLI at a custom data dir (or set a
+    different ``base_dir`` in ``config.json``), profiles created in the
+    dashboard landed in the default dir while ``slm profile list`` read a
+    different ``memory.db`` and reported the profile missing.
+
+    This function mirrors ``slm_home()`` so both surfaces agree. It is
+    evaluated lazily (at call time inside the properties below) rather
+    than at import, so a process that sets the env var after import —
+    e.g. tests, or a launcher that exports it late — still sees the
+    right path.
+    """
+    for var in ("SLM_DATA_DIR", "SL_MEMORY_PATH", "SLM_HOME"):
+        val = os.environ.get(var, "").strip()
+        if val:
+            return Path(val)
+    # Fall back to config.json's base_dir if present, else the hard default.
+    try:
+        _cfg = Path.home() / ".superlocalmemory" / "config.json"
+        if _cfg.exists():
+            with open(_cfg) as f:
+                _data = json.load(f)
+            _base = _data.get("base_dir")
+            if _base:
+                return Path(_base)
+    except (json.JSONDecodeError, OSError):
+        pass
+    return Path.home() / ".superlocalmemory"
+
+
+# V3 paths (migrated from ~/.claude-memory to ~/.superlocalmemory).
+# Exposed as module-level constants for backward compat with the many
+# route modules that do ``from .helpers import DB_PATH`` at import time,
+# but the *values* are resolved lazily so env overrides take effect.
+class _LazyPath:
+    """Path-like proxy that resolves the real path on first attribute access.
+
+    Importers bind to ``DB_PATH`` / ``MEMORY_DIR`` at import time; without
+    this proxy the value would be frozen before env vars are set. The
+    proxy defers resolution to ``_resolve_slm_home()`` and caches it.
+    """
+
+    __slots__ = ("_resolver", "_cached", "_suffix")
+
+    def __init__(self, resolver, suffix=""):
+        self._resolver = resolver
+        self._suffix = suffix
+        self._cached = None
+
+    def _resolve(self) -> Path:
+        if self._cached is None:
+            self._cached = self._resolver() / self._suffix if self._suffix else self._resolver()
+        return self._cached
+
+    def __fspath__(self) -> str:
+        return str(self._resolve())
+
+    def __truediv__(self, other) -> Path:
+        return self._resolve() / other
+
+    def __rtruediv__(self, other) -> Path:
+        return Path(other) / self._resolve()
+
+    def __str__(self) -> str:
+        return str(self._resolve())
+
+    def __repr__(self) -> str:
+        return f"_LazyPath({self._resolve()!r})"
+
+    # Forward common Path attributes used by callers (exists, mkdir, etc.).
+    def __getattr__(self, name):
+        return getattr(self._resolve(), name)
+
+
+MEMORY_DIR = _LazyPath(_resolve_slm_home)
+DB_PATH = _LazyPath(_resolve_slm_home, "memory.db")
 UI_DIR = Path(__file__).parent.parent / "ui"
-PROFILES_DIR = MEMORY_DIR / "profiles"
+PROFILES_DIR = _LazyPath(_resolve_slm_home, "profiles")
 
 
 # ---------------------------------------------------------------------------

--- a/src/superlocalmemory/server/ui.py
+++ b/src/superlocalmemory/server/ui.py
@@ -45,9 +45,12 @@ except ImportError:
 
 from superlocalmemory.server.security_middleware import SecurityHeadersMiddleware
 
-# V3 Paths (migrated from ~/.claude-memory to ~/.superlocalmemory)
-MEMORY_DIR = Path.home() / ".superlocalmemory"
-DB_PATH = MEMORY_DIR / "memory.db"
+# V3 Paths — reuse the lazy resolvers from routes.helpers so the dashboard
+# honours SLM_DATA_DIR / SL_MEMORY_PATH / SLM_HOME / config.json:base_dir
+# exactly like the CLI. Previously this hardcoded ~/.superlocalmemory, which
+# caused dashboard-created profiles to land in a different memory.db than
+# `slm profile list` reads when a custom data dir was configured.
+from superlocalmemory.server.routes.helpers import MEMORY_DIR, DB_PATH
 # V3.3.21: UI shipped inside the package for pip/npm installs.
 # Check package location first, then fall back to repo root for dev mode.
 _PKG_UI = Path(__file__).resolve().parent.parent / "ui"

--- a/tests/test_server/test_profile_path_resolution.py
+++ b/tests/test_server/test_profile_path_resolution.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3
+
+"""Regression test: dashboard and CLI must resolve the same SLM data dir.
+
+Before the fix, ``server/routes/helpers.py`` and ``server/ui.py`` hardcoded
+``MEMORY_DIR = Path.home() / ".superlocalmemory"``. The CLI, via
+``SLMConfig.load()`` → ``cli/_lazy_init.py:slm_home()``, honours the
+``SLM_DATA_DIR`` / ``SL_MEMORY_PATH`` / ``SLM_HOME`` env vars (and
+``config.json:base_dir``). When those diverged, a profile created in the
+dashboard landed in ``~/.superlocalmemory/memory.db`` while
+``slm profile list`` read a different DB and reported the profile missing.
+
+This test pins the invariant: the server-side path constants must resolve
+to the env-overridden directory, not the hard default.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def _reload_helpers():
+    """Reload the helpers module so module-level state picks up env vars.
+
+    The path constants are lazy proxies (resolved on first access), but we
+    reload to be defensive against any future eager binding.
+    """
+    import superlocalmemory.server.routes.helpers as helpers
+    return importlib.reload(helpers)
+
+
+def test_memory_dir_respects_slm_data_dir(tmp_path, monkeypatch):
+    """MEMORY_DIR must point at $SLM_DATA_DIR, not ~/.superlocalmemory."""
+    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
+    helpers = _reload_helpers()
+    assert str(helpers.MEMORY_DIR) == str(tmp_path), (
+        f"MEMORY_DIR resolved to {helpers.MEMORY_DIR!s}, expected {tmp_path}. "
+        "Dashboard profile writes would land in the wrong directory."
+    )
+    assert str(helpers.DB_PATH) == str(tmp_path / "memory.db")
+    assert str(helpers.PROFILES_DIR) == str(tmp_path / "profiles")
+
+
+def test_db_path_resolves_under_env_override(tmp_path, monkeypatch):
+    """DB_PATH must resolve under the env-overridden home, matching the CLI."""
+    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
+    helpers = _reload_helpers()
+    # The proxy must behave like a real Path for the operations the route
+    # helpers perform: __fspath__ (sqlite3.connect(str(DB_PATH))), /, exists().
+    assert os_fspath(helpers.DB_PATH) == str(tmp_path / "memory.db")
+    derived = helpers.MEMORY_DIR / "profiles.json"
+    assert isinstance(derived, Path)
+    assert derived == tmp_path / "profiles.json"
+    assert helpers.DB_PATH.exists() is False  # nothing created yet
+
+
+def test_dashboard_and_cli_agree_on_profile_dir(tmp_path, monkeypatch):
+    """End-to-end: a profile written via the dashboard path helpers must be
+    visible to the CLI read path, because both resolve the same DB."""
+    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
+    helpers = _reload_helpers()
+
+    # CLI side: DatabaseManager writes to config.db_path (env-resolved).
+    from superlocalmemory.core.config import SLMConfig
+    from superlocalmemory.storage.database import DatabaseManager
+    from superlocalmemory.storage import schema
+
+    config = SLMConfig.load()
+    assert str(config.db_path) == str(tmp_path / "memory.db"), (
+        "CLI config.db_path does not match env override — test premise broken"
+    )
+    db = DatabaseManager(config.db_path)
+    db.initialize(schema)
+    db.execute(
+        "INSERT OR IGNORE INTO profiles (profile_id, name) VALUES (?, ?)",
+        ("work", "work"),
+    )
+
+    # Dashboard side: route helpers read DB_PATH (must be the same file).
+    assert str(helpers.DB_PATH) == str(config.db_path), (
+        "Dashboard DB_PATH and CLI config.db_path diverge — profiles created "
+        "in the dashboard would be invisible to `slm profile list`."
+    )
+
+    # Dashboard read path sees the CLI-written profile.
+    merged = helpers.sync_profiles()
+    ids = {p["profile_id"] for p in merged}
+    assert "work" in ids, f"Dashboard sync_profiles() did not see 'work': {ids}"
+
+
+def os_fspath(p) -> str:
+    import os
+    return os.fspath(p)


### PR DESCRIPTION
## Problem

Profiles created in the dashboard (via `#ng-profile-container` → `POST /api/profiles/create`) were invisible to `slm profile list` on the CLI whenever the SLM data directory was not the hard default `~/.superlocalmemory`.

The dashboard profile routes hardcoded `MEMORY_DIR = Path.home() / ".superlocalmemory"` (`server/routes/helpers.py:73-74`, `server/ui.py:49-50`), while the CLI resolves the data dir through `SLMConfig.load()` → `cli/_lazy_init.py:slm_home()`, which honours `SLM_DATA_DIR` → `SL_MEMORY_PATH` → `SLM_HOME` env vars and `config.json:base_dir`.

When paths diverged (custom env var, non-default `base_dir`, or running the dashboard under a different user/env), the dashboard wrote to `~/.superlocalmemory/memory.db` while `slm profile list` read a different `memory.db` and reported the profile as missing.

## Solution

Replace the hardcoded `MEMORY_DIR` / `DB_PATH` / `PROFILES_DIR` constants in `server/routes/helpers.py` with a `_LazyPath` proxy that resolves via `_resolve_slm_home()` — mirroring `cli/_lazy_init.py:slm_home()`. The proxy defers resolution to first access so env vars set after import (tests, launchers) still take effect.

`server/ui.py` now imports `MEMORY_DIR` / `DB_PATH` from `routes.helpers` instead of redefining them, giving a single source of truth for path resolution across the server.

**Alternatives considered:**
- *Make every route call `slm_home()` directly* — rejected: would require touching every route module that does `from .helpers import DB_PATH` at import time (10+ files), widening the blast radius.
- *Resolve eagerly at import* — rejected: env vars set after import (common in test fixtures and launchers) would be missed. The lazy proxy caches on first attribute access.

## Changes

**`src/superlocalmemory/server/routes/helpers.py`**
| Change | Why |
|---|---|
| Added `_resolve_slm_home()` | Mirrors `cli/_lazy_init.py:slm_home()` — same env-var priority + `config.json:base_dir` fallback |
| Added `_LazyPath` proxy class | Defers path resolution to first access so post-import env overrides take effect; forwards `__fspath__`, `__truediv__`, `__getattr__` for all existing call sites (`str(DB_PATH)`, `MEMORY_DIR / "x"`, `DB_PATH.exists()`) |
| Replaced `MEMORY_DIR`/`DB_PATH`/`PROFILES_DIR` constants with `_LazyPath` instances | Existing `from .helpers import DB_PATH` imports keep working; values now resolve dynamically |
| Added `import os` | Required by `_resolve_slm_home()` for `os.environ` |

**`src/superlocalmemory/server/ui.py`**
| Change | Why |
|---|---|
| Removed local `MEMORY_DIR`/`DB_PATH` definitions | Eliminates the second hardcoded copy — single source of truth in `routes.helpers` |
| Imports `MEMORY_DIR`/`DB_PATH` from `routes.helpers` | Dashboard now resolves paths identically to the CLI |

**`tests/test_server/test_profile_path_resolution.py`** (new)
- `test_memory_dir_respects_slm_data_dir` — `MEMORY_DIR`/`DB_PATH`/`PROFILES_DIR` follow `SLM_DATA_DIR`
- `test_db_path_resolves_under_env_override` — proxy behaves like a real `Path` (`__fspath__`, `/`, `exists()`)
- `test_dashboard_and_cli_agree_on_profile_dir` — end-to-end: CLI writes a profile, dashboard `sync_profiles()` sees it

## What Does Not Change

- **API contracts unchanged** — no route signatures, request/response schemas, or URL paths modified.
- **`profiles.json` format unchanged** — still the dict-keyed-by-name format the dashboard writes; the latent `ProfileManager` list-format mismatch (dead code, never instantiated) is out of scope.
- **CLI behaviour unchanged** — `slm profile list` / `create` / `switch` already resolved paths correctly; only the server side was wrong.
- **No new dependencies** — `_LazyPath` uses stdlib only (`pathlib`, `os`). Test file uses stdlib + `pytest` (already a dev dependency).
- **Existing `from .helpers import DB_PATH` imports** — all 10+ route modules continue to work unchanged; the proxy forwards every `Path` attribute they use.

## Regression Tests

**Test that fails before the fix** (`tests/test_server/test_profile_path_resolution.py`):
```python
def test_dashboard_and_cli_agree_on_profile_dir(tmp_path, monkeypatch):
    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
    helpers = _reload_helpers()
    from superlocalmemory.core.config import SLMConfig
    config = SLMConfig.load()
    # CLI resolves to tmp_path/memory.db, dashboard hardcodes ~/.superlocalmemory
    assert str(helpers.DB_PATH) == str(config.db_path)
```
Result: **FAIL** — `AssertionError: assert '/Users/barryg/.superlocalmemory/memory.db' == '/private/var/.../memory.db'`

All three tests fail against `main` and pass with this fix.

## Test Plan

**Regression test (fails before fix, passes after):**
- `tests/test_server/test_profile_path_resolution.py::test_memory_dir_respects_slm_data_dir`
  - Before: `AssertionError: MEMORY_DIR resolved to /Users/barryg/.superlocalmemory, expected <tmp>`
  - After: PASS
- `tests/test_server/test_profile_path_resolution.py::test_db_path_resolves_under_env_override`
  - Before: `AssertionError` on `os.fspath(DB_PATH)` mismatch
  - After: PASS
- `tests/test_server/test_profile_path_resolution.py::test_dashboard_and_cli_agree_on_profile_dir`
  - Before: `AssertionError: Dashboard DB_PATH and CLI config.db_path diverge`
  - After: PASS

**Existing test suites (confirm no regression):**
- [ ] `PYTHONPATH=src python -m pytest tests/test_server/ -q` passes locally
- [ ] `PYTHONPATH=src python -m pytest tests/test_v3_api.py -q` — server route smoke

**Manual verification steps:**
- [ ] `SLM_DATA_DIR=/tmp/slm-x slm dashboard` then create a profile in the UI → `SLM_DATA_DIR=/tmp/slm-x slm profile list` shows it
- [ ] No env override: dashboard create → `slm profile list` still shows it (no regression on default path)

## Breaking Changes

None. `MEMORY_DIR` / `DB_PATH` / `PROFILES_DIR` remain importable from `superlocalmemory.server.routes.helpers` with the same names; they now resolve dynamically instead of being frozen at import.

## Reviewer Notes

- The `_LazyPath` proxy caches the resolved `Path` on first attribute access (`_cached`). This is intentional: env vars are read once and the result is stable for the process lifetime, matching the CLI's `slm_home()` semantics. If a test mutates `SLM_DATA_DIR` mid-process and reloads `helpers` (as the regression tests do), the cache is reset by the `importlib.reload`.
- The latent `ProfileManager` list-vs-dict format mismatch (`core/profiles.py`) is deliberately out of scope — it's dead code (never instantiated in production) and fixing it would co-mix concerns. Flagged for a follow-up.