### PR TITLE
fix(maintenance): tolerate tz-naive created_at in Langevin backfill

### DIFF
--- a/src/superlocalmemory/core/maintenance.py
+++ b/src/superlocalmemory/core/maintenance.py
@@ -37,6 +37,25 @@ _LANGEVIN_DIM = 8
 _MAX_NORM = 0.99
 
 
+def _age_days(created_at: str | None) -> float:
+    """Age in days from an ISO timestamp.
+
+    Naive timestamps (no offset, no Z) are assumed UTC — some store paths
+    persist created_at without timezone info, and subtracting a naive
+    datetime from datetime.now(UTC) raises TypeError, which previously
+    aborted the whole backfill loop.
+    """
+    if not created_at:
+        return 0.0
+    try:
+        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return 0.0
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=UTC)
+    return max(0.0, (datetime.now(UTC) - created).total_seconds() / 86400.0)
+
+
 def _compute_equilibrium_radius(
     access_count: int,
     age_days: float,
@@ -137,13 +156,7 @@ def run_maintenance(
             for f in facts:
                 if f.langevin_position is not None:
                     continue
-                created = datetime.fromisoformat(
-                    f.created_at.replace("Z", "+00:00")
-                ) if f.created_at else datetime.now(UTC)
-                age_days = max(
-                    0.0,
-                    (datetime.now(UTC) - created).total_seconds() / 86400.0,
-                )
+                age_days = _age_days(f.created_at)
                 # Strategy B: metadata-aware seed position
                 position = _seed_langevin_position(
                     f.access_count, age_days, f.importance,
@@ -183,13 +196,7 @@ def run_maintenance(
             for f in facts:
                 if f.langevin_position is None:
                     continue
-                created = datetime.fromisoformat(
-                    f.created_at.replace("Z", "+00:00")
-                ) if f.created_at else datetime.now(UTC)
-                age_days = max(
-                    0.0,
-                    (datetime.now(UTC) - created).total_seconds() / 86400.0,
-                )
+                age_days = _age_days(f.created_at)
                 fact_dicts.append({
                     "fact_id": f.fact_id,
                     "position": f.langevin_position,
@@ -239,13 +246,7 @@ def run_maintenance(
                         dt=config.math.langevin_dt,
                         temperature=eff_temp,
                     )
-                    created = datetime.fromisoformat(
-                        f.created_at.replace("Z", "+00:00")
-                    ) if f.created_at else datetime.now(UTC)
-                    age_days = max(
-                        0.0,
-                        (datetime.now(UTC) - created).total_seconds() / 86400.0,
-                    )
+                    age_days = _age_days(f.created_at)
                     new_pos, weight = coupled_ld.step(
                         position=f.langevin_position,
                         access_count=f.access_count,

--- a/tests/test_core/test_langevin_init.py
+++ b/tests/test_core/test_langevin_init.py
@@ -287,6 +287,25 @@ class TestMaintenanceBackfill:
         assert "langevin_backfilled" in counts
         assert counts["langevin_backfilled"] == 0
 
+    def test_backfills_facts_with_naive_created_at(self) -> None:
+        """Naive (tz-less) created_at strings must not abort the backfill.
+
+        Regression: some store paths persist created_at without timezone
+        info; subtracting the parsed naive datetime from datetime.now(UTC)
+        raised TypeError, which aborted the whole backfill loop and left
+        every remaining fact unpositioned.
+        """
+        config = self._make_config()
+        db = MagicMock()
+        naive = self._make_fact("f1", langevin_position=None)
+        naive.created_at = datetime.now().isoformat()  # no tzinfo, no Z
+        aware = self._make_fact("f2", langevin_position=None, age_days=30.0)
+        db.get_all_facts.return_value = [naive, aware]
+
+        counts = run_maintenance(db, config, "default")
+
+        assert counts["langevin_backfilled"] == 2
+
     def test_disabled_langevin_skips_backfill(self) -> None:
         """When langevin_persist_positions is False, no backfill occurs."""
         config = self._make_config()


### PR DESCRIPTION
## Problem

`run_maintenance()` parses `fact.created_at` with `datetime.fromisoformat(created_at.replace("Z", "+00:00"))`. When the stored timestamp is tz-naive (no offset, no `Z` — some store paths persist `created_at` this way), the result is a naive datetime, and `datetime.now(UTC) - created` raises `TypeError: can't subtract offset-naive and offset-aware datetimes`.

Because the whole backfill loop sits inside a single `try`, the first naive fact aborts the loop, and every remaining unpositioned fact is skipped — on every maintenance cycle. Observed in production (v3.6.17, Mode C) as `slm health` permanently reporting `lifecycle_positioned` short of `total_facts` (251/253), with the daemon log showing:

Here's `slm health` showing 251/253
```
❯ slm health
Ollama embedder not available (model=nomic-embed-text). Falling back.
Ollama unavailable; falling back to sentence-transformers subprocess
Math Layer Health:
  Total facts: 253
  Fisher-Rao indexed: 253/253
  Langevin positioned: **251/253**
  Mode: C
```
And here's the attempt to backfill failing
```
2026-07-10 13:44:37,835 Loaded adjacency cache: 87 nodes, 231 edges, 17 entity mappings for profile default
2026-07-10 13:48:21,734 Langevin backfill failed: can't subtract offset-naive and offset-aware datetimes
2026-07-10 13:48:21,736 Langevin maintenance failed: can't subtract offset-naive and offset-aware datetimes
2026-07-10 13:48:21,739 Maintenance complete: 0 backfilled, 0 Langevin, 0 Fisher-coupled, 0 Sheaf, 0 entity-summaries
2026-07-10 13:48:21,743 Scheduled maintenance complete: {'langevin_backfilled': 0, 'langevin_updated': 0, 'fisher_coupled': 0, 'sheaf_checked': 0, 'entity_summaries_consolidated': 0, 'orphan_metadata_gc': 0}
```

The same parse block is copy-pasted at three sites in `maintenance.py` (backfill 1a, batch step 1b, Fisher-Langevin coupling), so all three were vulnerable.

## Proposed Solution

Extract the age computation into a single `_age_days(created_at)` helper that coerces naive timestamps to UTC (`created.replace(tzinfo=UTC)`) before subtracting, and tolerates unparseable values by returning `0.0`. All three sites now route through it.

## Changes

- `src/superlocalmemory/core/maintenance.py`: new `_age_days()` helper; the three duplicated parse blocks replaced with calls to the helper (net −20 lines).
- `tests/test_core/test_langevin_init.py`: regression test `test_backfills_facts_with_naive_created_at` — fails on the broken baseline with the exact production error, passes with the fix. Full file: 22/22 pass.

## What Does Not Change

- Behaviour for tz-aware timestamps (`Z` or explicit offset) is unaffected.
- Other maintenance passes untouched