### PR TITLE
fix(server,cli): resolve remaining hardcoded ~/.superlocalmemory paths via slm_home()

### DIFF
--- a/src/superlocalmemory/cli/commands.py
+++ b/src/superlocalmemory/cli/commands.py
@@ -337,11 +337,11 @@ def cmd_restart(args: Namespace) -> None:
     """
     import os
     import time
-    from pathlib import Path
 
     use_json = getattr(args, "json", False)
     open_dashboard = getattr(args, "dashboard", False)
-    slm_dir = Path.home() / ".superlocalmemory"
+    from superlocalmemory.cli._lazy_init import slm_home
+    slm_dir = slm_home()
     steps: list[dict] = []
 
     def _log(step: int, name: str, status: str, detail: str = ""):
@@ -1263,10 +1263,10 @@ def cmd_recall(args: Namespace) -> None:
 
 def _cli_record_signals(config, query, results):
     """Record learning signals from CLI recall (no MCP dependency)."""
-    from pathlib import Path
     from superlocalmemory.learning.feedback import FeedbackCollector
     from superlocalmemory.learning.signals import LearningSignals
-    slm_dir = Path.home() / ".superlocalmemory"
+    from superlocalmemory.cli._lazy_init import slm_home
+    slm_dir = slm_home()
     pid = config.active_profile
     fact_ids = [r.fact.fact_id for r in results[:10]]
     if not fact_ids:

--- a/src/superlocalmemory/cli/daemon.py
+++ b/src/superlocalmemory/cli/daemon.py
@@ -32,6 +32,8 @@ from pathlib import Path
 import threading
 from threading import Thread
 
+from ._lazy_init import slm_home
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -40,8 +42,10 @@ except ValueError:
     _DEFAULT_PORT = 8765
 _LEGACY_PORT = 8767   # backward-compat redirect
 _DEFAULT_IDLE_TIMEOUT = 0  # v3.4.3: 24/7 default (was 1800)
-_PID_FILE = Path.home() / ".superlocalmemory" / "daemon.pid"
-_PORT_FILE = Path.home() / ".superlocalmemory" / "daemon.port"
+# Resolved via slm_home() so the client finds the daemon started by
+# server/unified_daemon.py when SLM_DATA_DIR/SLM_HOME point off-home.
+_PID_FILE = slm_home() / "daemon.pid"
+_PORT_FILE = slm_home() / "daemon.port"
 
 
 # ---------------------------------------------------------------------------

--- a/src/superlocalmemory/server/api.py
+++ b/src/superlocalmemory/server/api.py
@@ -23,13 +23,12 @@ from pydantic import BaseModel
 import uvicorn
 
 from superlocalmemory.server.security_middleware import SecurityHeadersMiddleware
-from superlocalmemory.server.routes.helpers import SLM_VERSION
+from superlocalmemory.server.routes.helpers import SLM_VERSION, DB_PATH
 
 logger = logging.getLogger("superlocalmemory.api_server")
 
-# V3 paths
-MEMORY_DIR = Path.home() / ".superlocalmemory"
-DB_PATH = MEMORY_DIR / "memory.db"
+# V3 paths — DB_PATH comes from routes.helpers so this server resolves the
+# data dir the same way as the dashboard routes and the CLI.
 # V3.3.21: UI shipped inside the package for pip/npm installs.
 _PKG_UI = Path(__file__).resolve().parent.parent / "ui"
 _REPO_UI = Path(__file__).resolve().parent.parent.parent.parent / "ui"

--- a/src/superlocalmemory/server/bandit_loops.py
+++ b/src/superlocalmemory/server/bandit_loops.py
@@ -42,7 +42,8 @@ def _learning_db(config: Any) -> Path:
         cand = getattr(config, "learning_db_path", None)
         if cand is not None:
             return Path(cand)
-    return Path.home() / ".superlocalmemory" / "learning.db"
+    from superlocalmemory.server.routes.helpers import MEMORY_DIR
+    return MEMORY_DIR / "learning.db"
 
 
 def _memory_db(config: Any) -> Path:
@@ -50,7 +51,8 @@ def _memory_db(config: Any) -> Path:
         cand = getattr(config, "db_path", None)
         if cand is not None:
             return Path(cand)
-    return Path.home() / ".superlocalmemory" / "memory.db"
+    from superlocalmemory.server.routes.helpers import MEMORY_DIR
+    return MEMORY_DIR / "memory.db"
 
 
 def _profile_id(config: Any) -> str:

--- a/src/superlocalmemory/server/routes/agents.py
+++ b/src/superlocalmemory/server/routes/agents.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
-from .helpers import DB_PATH
+from .helpers import DB_PATH, MEMORY_DIR
 
 logger = logging.getLogger("superlocalmemory.routes.agents")
 router = APIRouter()
@@ -43,8 +43,7 @@ async def get_agents(
     if not REGISTRY_AVAILABLE:
         return {"agents": [], "count": 0, "message": "Agent registry not available"}
     try:
-        from pathlib import Path
-        registry_path = Path.home() / ".superlocalmemory" / "agents.json"
+        registry_path = MEMORY_DIR / "agents.json"
         registry = AgentRegistry(persist_path=registry_path)
         agents = registry.list_agents()
         return {
@@ -62,8 +61,7 @@ async def get_agent_stats(request: Request):
     if not REGISTRY_AVAILABLE:
         return {"total_agents": 0, "message": "Agent registry not available"}
     try:
-        from pathlib import Path
-        registry_path = Path.home() / ".superlocalmemory" / "agents.json"
+        registry_path = MEMORY_DIR / "agents.json"
         registry = AgentRegistry(persist_path=registry_path)
         agents = registry.list_agents()
         return {"total_agents": len(agents)}

--- a/src/superlocalmemory/server/routes/brain.py
+++ b/src/superlocalmemory/server/routes/brain.py
@@ -52,6 +52,8 @@ from superlocalmemory.core.security_primitives import (
 from superlocalmemory.learning.database import LearningDatabase
 from superlocalmemory.learning.features import FEATURE_DIM
 
+from .helpers import MEMORY_DIR
+
 logger = logging.getLogger("superlocalmemory.routes.brain")
 
 router = APIRouter(prefix="/api/v3", tags=["brain"])
@@ -71,9 +73,11 @@ _VERSION: str = "3.4.23"
 # NOTE: do NOT add the literal forbidden-key strings here — the U4 grep
 # guard runs over this file.
 
-# Memory directory (home-dir based). Always resolved at call time so that
-# tests can override via monkeypatch on ``_learning_db_path``.
-_MEMORY_DIR_DEFAULT = Path.home() / ".superlocalmemory"
+# Memory directory — resolved via routes.helpers so the Brain routes agree
+# with the rest of the dashboard (env overrides + config.json:base_dir).
+# Always resolved at call time so that tests can override via monkeypatch
+# on ``_learning_db_path``.
+_MEMORY_DIR_DEFAULT = MEMORY_DIR
 
 
 def _learning_db_path() -> Path:
@@ -565,9 +569,8 @@ def _adapter_last_sync_ago(adapter_name: str) -> int | None:
     try:
         import sqlite3 as _sqlite3
         from datetime import datetime as _dt, timezone as _tz
-        from pathlib import Path as _P
 
-        memory_db = _P.home() / ".superlocalmemory" / "memory.db"
+        memory_db = _memory_db_path()
         if not memory_db.exists():
             return None
         conn = _sqlite3.connect(
@@ -986,7 +989,6 @@ def _compute_outcome_queue_stats(profile_id: str) -> dict:
     actually flowing: recall → enqueue → persist → finalize.
     """
     import sqlite3
-    from pathlib import Path
     try:
         from superlocalmemory.learning.outcome_queue import (
             get_counters, queue_size,
@@ -995,8 +997,7 @@ def _compute_outcome_queue_stats(profile_id: str) -> dict:
         qsz = queue_size()
     except Exception:
         counters, qsz = {}, 0
-    home = Path.home() / ".superlocalmemory"
-    db = home / "memory.db"
+    db = _memory_db_path()
     pending_now = 0
     if db.exists():
         try:
@@ -1030,9 +1031,7 @@ def _compute_outcome_queue_stats(profile_id: str) -> dict:
 def _compute_reward_preview(profile_id: str) -> dict:
     """Reward-tile aggregate — count + mean reward over the last 24h."""
     import sqlite3
-    from pathlib import Path
-    home = Path.home() / ".superlocalmemory"
-    db = home / "memory.db"
+    db = _memory_db_path()
     default = {
         "is_real": False, "rows_24h": 0, "mean_reward_24h": 0.0,
         "source": "action_outcomes",

--- a/src/superlocalmemory/server/routes/v3_api.py
+++ b/src/superlocalmemory/server/routes/v3_api.py
@@ -712,8 +712,9 @@ async def recall_trace(request: Request):
 def _record_learning_signals(query: str, results: list) -> None:
     """Record feedback + co-retrieval + confidence boost for any recall."""
     from superlocalmemory.core.config import SLMConfig
+    from superlocalmemory.server.routes.helpers import MEMORY_DIR
 
-    slm_dir = Path.home() / ".superlocalmemory"
+    slm_dir = MEMORY_DIR
     config = SLMConfig.load()
     pid = config.active_profile
     fact_ids = [r.get("fact_id", "") for r in results[:10] if r.get("fact_id")]

--- a/src/superlocalmemory/server/unified_daemon.py
+++ b/src/superlocalmemory/server/unified_daemon.py
@@ -51,13 +51,16 @@ from fastapi.middleware.gzip import GZipMiddleware
 from pydantic import BaseModel
 
 from superlocalmemory.core.config import CANONICAL_RECALL_LIMIT
+from superlocalmemory.cli._lazy_init import slm_home
 
 logger = logging.getLogger("superlocalmemory.unified_daemon")
 
 _DEFAULT_PORT = 8765
 _LEGACY_PORT = 8767
-_PID_FILE = Path.home() / ".superlocalmemory" / "daemon.pid"
-_PORT_FILE = Path.home() / ".superlocalmemory" / "daemon.port"
+# Runtime files resolve via slm_home() (env-only, stdlib) so the daemon and
+# the CLI client (cli/daemon.py) always agree on where pid/port live.
+_PID_FILE = slm_home() / "daemon.pid"
+_PORT_FILE = slm_home() / "daemon.port"
 
 
 # ---------------------------------------------------------------------------
@@ -451,7 +454,7 @@ async def lifespan(application: FastAPI):
             _slm_version = _pkg_version("superlocalmemory")
         except Exception:
             _slm_version = "unknown"
-        _version_marker = _VP.home() / ".superlocalmemory" / ".last_version"
+        _version_marker = slm_home() / ".last_version"
         _prev = None
         if _version_marker.exists():
             try:
@@ -488,9 +491,8 @@ async def lifespan(application: FastAPI):
     # engine init so later queries see the expected columns/tables.
     # Non-fatal: any failure here is logged and the daemon still starts.
     try:
-        from pathlib import Path as _P
         from superlocalmemory.storage.migration_runner import apply_all
-        _home = _P.home() / ".superlocalmemory"
+        _home = slm_home()
         _learning_db = _home / "learning.db"
         _memory_db = _home / "memory.db"
         _result = apply_all(_learning_db, _memory_db)
@@ -793,10 +795,9 @@ async def lifespan(application: FastAPI):
         # Previously routed through WorkerPool → recall_worker subprocess,
         # which loaded a duplicate MemoryEngine (~800 MB waste).
         try:
-            from pathlib import Path as _QP
             from superlocalmemory.core.queue_consumer import QueueConsumer
             from superlocalmemory.core.recall_queue import RecallQueue
-            _queue_db = _QP.home() / ".superlocalmemory" / "recall_queue.db"
+            _queue_db = slm_home() / "recall_queue.db"
             _recall_queue = RecallQueue(_queue_db)
             _queue_consumer = QueueConsumer(
                 queue=_recall_queue,
@@ -854,7 +855,7 @@ async def lifespan(application: FastAPI):
         mesh_enabled = getattr(config, 'mesh_enabled', True) if config else True
         if mesh_enabled:
             from superlocalmemory.mesh.broker import MeshBroker
-            db_path = config.db_path if config else Path.home() / ".superlocalmemory" / "memory.db"
+            db_path = config.db_path if config else slm_home() / "memory.db"
             mesh_broker = MeshBroker(str(db_path))
             mesh_broker.start_cleanup()
             application.state.mesh_broker = mesh_broker
@@ -883,8 +884,7 @@ async def lifespan(application: FastAPI):
     if os.environ.get("SLM_SIGNALS_ENABLED", "1") != "0":
         try:
             from superlocalmemory.learning import signal_worker as _sw
-            from pathlib import Path as _P
-            _learning_db = _P.home() / ".superlocalmemory" / "learning.db"
+            _learning_db = slm_home() / "learning.db"
             _sw.start(_learning_db)
             application.state.signal_worker_started = True
             logger.info("signal_worker started on %s", _learning_db)
@@ -2311,8 +2311,7 @@ def start_server(port: int = _DEFAULT_PORT) -> None:
         from superlocalmemory.migrations.v3_4_25_to_v3_4_26 import (
             is_ready as _is_ready, migrate as _migrate,
         )
-        _data = Path(os.environ.get("SLM_DATA_DIR")
-                     or Path.home() / ".superlocalmemory")
+        _data = slm_home()
         if not _is_ready(_data):
             _migrate(_data)
     except Exception as exc:
@@ -2327,7 +2326,7 @@ def start_server(port: int = _DEFAULT_PORT) -> None:
     # v3.4.32: Continuous pending-queue materializer with recall priority.
     _start_pending_materializer()
 
-    log_dir = Path.home() / ".superlocalmemory" / "logs"
+    log_dir = slm_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Bind address. `SLM_DAEMON_HOST` is the canonical name; `SLM_HOST` is
@@ -2383,7 +2382,7 @@ def rotate_oversized_logs(log_dir: Optional[Path] = None,
     Keeps one rotated copy (.1). Safe under concurrent start attempts:
     rename is atomic on POSIX, and truncation is idempotent.
     """
-    log_dir = log_dir or (Path.home() / ".superlocalmemory" / "logs")
+    log_dir = log_dir or (slm_home() / "logs")
     try:
         log_dir.mkdir(parents=True, exist_ok=True)
     except Exception:

--- a/tests/test_server/test_data_dir_leftovers.py
+++ b/tests/test_server/test_data_dir_leftovers.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3
+
+"""Regression tests: remaining server/CLI modules must resolve the SLM data
+dir via the env chain, not a hardcoded ``Path.home() / ".superlocalmemory"``.
+
+Follow-up to ``test_profile_path_resolution.py`` (which pinned the invariant
+for ``routes/helpers.py`` + ``ui.py``). These cover the leftovers:
+
+- ``routes/brain.py``      — Brain-panel learning/memory DB paths
+- ``server/bandit_loops.py`` — reward-loop DB fallbacks (config=None)
+- ``server/api.py``        — standalone API server DB_PATH
+- ``server/unified_daemon.py`` + ``cli/daemon.py`` — daemon.pid/daemon.port
+  must resolve identically on both sides, or the CLI client cannot find a
+  daemon started with an off-home data dir.
+- ``cli/commands.py``      — CLI recall learning signals write to the same
+  learning.db the daemon reads.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def _reload(modname):
+    mod = importlib.import_module(modname)
+    return importlib.reload(mod)
+
+
+def test_brain_db_paths_respect_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
+    _reload("superlocalmemory.server.routes.helpers")
+    brain = _reload("superlocalmemory.server.routes.brain")
+    assert brain._learning_db_path() == tmp_path / "learning.db"
+    assert brain._memory_db_path() == tmp_path / "memory.db"
+
+
+def test_bandit_loops_fallbacks_respect_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
+    _reload("superlocalmemory.server.routes.helpers")
+    bandit = _reload("superlocalmemory.server.bandit_loops")
+    assert bandit._learning_db(None) == tmp_path / "learning.db"
+    assert bandit._memory_db(None) == tmp_path / "memory.db"
+
+
+def test_api_server_db_path_respects_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
+    _reload("superlocalmemory.server.routes.helpers")
+    api = _reload("superlocalmemory.server.api")
+    assert str(api.DB_PATH) == str(tmp_path / "memory.db")
+
+
+def test_daemon_pid_port_agree_between_server_and_cli(tmp_path, monkeypatch):
+    """The daemon writes pid/port where the CLI client looks for them."""
+    monkeypatch.setenv("SLM_DATA_DIR", str(tmp_path))
+    cli_daemon = _reload("superlocalmemory.cli.daemon")
+    unified = _reload("superlocalmemory.server.unified_daemon")
+    assert cli_daemon._PID_FILE == tmp_path / "daemon.pid"
+    assert cli_daemon._PORT_FILE == tmp_path / "daemon.port"
+    assert Path(unified._PID_FILE) == cli_daemon._PID_FILE
+    assert Path(unified._PORT_FILE) == cli_daemon._PORT_FILE


### PR DESCRIPTION
Fixes #67. Follow-up to 816f836: replaces the remaining hardcoded `Path.home() / ".superlocalmemory"` in the server tree and the CLI daemon client with the two resolvers that already exist.

Route modules and the standalone API server resolve through `routes.helpers` `MEMORY_DIR`/`DB_PATH` (env chain + `config.json:base_dir`). Daemon runtime files (`daemon.pid`/`daemon.port`, logs, version marker) and `cli/daemon.py` both use `cli/_lazy_init.py:slm_home()`, so pid/port discovery agrees on both sides. Functional consequences before this fix, with a data dir relocated via `SLM_DATA_DIR`/`SLM_HOME`: startup schema migrations ran against the wrong DBs, `signal_worker` drained recall signals into a `learning.db` the daemon never reads, Brain-panel tiles read empty DBs, and `slm serve status`/`stop` couldn't find a daemon started off-home.

Verified with `tests/test_server/test_data_dir_leftovers.py` (fails on v3.6.23, passes here), the existing `test_server`/`test_cli`/`test_api` suites, and end-to-end: daemon booted with `SLM_DATA_DIR` pointing at a seeded 2k-fact DB and `HOME` pointing at an empty dir — `/api/stats`, `/api/memories`, `/api/timeline`, `/api/graph`, `/api/profiles` return the seeded data, migrations and signal_worker target the data dir, and nothing DB-related appears under `$HOME/.superlocalmemory` from the touched modules.

No behavior change when the env vars are unset (everything still falls back to `~/.superlocalmemory`).
