### PR TITLE
fix(ingestion): don't re-apply admission gate at materialization

### DIFF
--- a/src/superlocalmemory/core/store_pipeline.py
+++ b/src/superlocalmemory/core/store_pipeline.py
@@ -208,21 +208,33 @@ def run_store(
     if not pre_authorized:
         hooks.run_pre("store", hook_ctx)
 
-    if entropy_gate and not entropy_gate.should_pass(content):
+    # Admission gates apply to FRESH submissions only. A materialization pass
+    # re-runs this pipeline for content whose queryable projection was already
+    # committed at submit (``queryable_fact_ids`` is set). Re-applying admission
+    # here — the entropy near-duplicate gate especially — would discard that
+    # already-committed fact (return []) and wedge the operation in an endless
+    # materialize retry loop ("materialization produced no final facts"). The
+    # near-duplicate verdict is expected at materialize: the submitted
+    # projection itself is in the gate's window. Admission was already decided
+    # at submit (store_fast enforces the same gates), so skip it here.
+    is_materialization = bool(queryable_fact_ids)
+
+    if entropy_gate and not is_materialization and not entropy_gate.should_pass(content):
         return []
 
     # v3.5.0: store-side quality gate (H3). Reject prompt-template leakage,
     # empty placeholders, and other non-memory content BEFORE it enters the
     # DB. Uses the shared is_low_quality from core/injection so both store
     # AND injection filter by identical rules. Saves DB IO + recall pollution.
-    try:
-        from superlocalmemory.core.injection import is_low_quality
-        if is_low_quality(content):
-            logger.debug("Store rejected (low-quality content): %s...",
-                         content[:80].replace("\n", " "))
-            return []
-    except Exception:
-        pass  # Best-effort gate; store succeeds if import fails
+    if not is_materialization:
+        try:
+            from superlocalmemory.core.injection import is_low_quality
+            if is_low_quality(content):
+                logger.debug("Store rejected (low-quality content): %s...",
+                             content[:80].replace("\n", " "))
+                return []
+        except Exception:
+            pass  # Best-effort gate; store succeeds if import fails
 
     from superlocalmemory.encoding.temporal_parser import TemporalParser
     parser = temporal_parser or TemporalParser()

--- a/tests/test_core/test_canonical_ingestion_materialization.py
+++ b/tests/test_core/test_canonical_ingestion_materialization.py
@@ -31,6 +31,47 @@ def _install_m018(engine) -> None:
         M018_ingestion_operations.apply(conn)
 
 
+def test_materialization_ignores_admission_gate_for_submitted_operation(
+    engine_with_mock_deps,
+) -> None:
+    """An already-submitted operation must materialize even if the admission
+    gate now rejects its content.
+
+    Regression: ``run_store`` applied the entropy / low-quality *admission* gate
+    at the materialize step. Content whose queryable projection was already
+    committed at submit (e.g. near-identical session-close summaries, which the
+    entropy gate scores as >0.95 near-duplicates once the window is warm) was
+    re-rejected — ``run_store`` returned ``[]`` — so materialization raised
+    "materialization produced no final facts", the operation was marked FAILED,
+    and the background worker retried it forever. Admission belongs to submit,
+    not to materialization.
+    """
+    engine = engine_with_mock_deps
+    _install_m018(engine)
+    command = build_engine_ingestion_command(engine)
+    receipt = command.submit(IngestionRequest(
+        content=(
+            "Alice owns the incident review process and records every approved "
+            "corrective action for the platform team."
+        ),
+        profile_id=engine._profile_id,
+        source_type="http",
+        idempotency_key="admission-gate-at-materialize",
+        trusted_actor_id="daemon-capability:owned-instance",
+    ))
+    assert receipt.state is IngestionState.QUERYABLE
+    queryable_id = receipt.queryable_fact_ids[0]
+
+    # The gate now treats the content as a near-duplicate (its rolling window
+    # already holds the committed projection). Pre-fix this discarded the fact.
+    with patch.object(engine._entropy_gate, "should_pass", return_value=False):
+        completed = command.materialize(receipt.operation_id)
+
+    assert completed.state is IngestionState.COMPLETE
+    assert completed.last_error == ""
+    assert queryable_id in completed.final_fact_ids
+
+
 def test_materialization_promotes_queryable_fact_without_duplicate_memory(
     engine_with_mock_deps,
 ) -> None:


### PR DESCRIPTION
## Problem

Under the v3.7 two-phase durable ingestion (`submit → QUERYABLE`, then background
`materialize → COMPLETE`), operations whose content is a **near-duplicate of recently-stored
facts get permanently stuck** and are retried forever. The daemon logs, every 1–5 minutes:

```
Ingestion operation <id> failed: materialization produced no final facts
```

Observed with auto-generated session-close summaries (nearly identical templated text, e.g.
`[<agent>] session ended <ts> | branch: … | recent: …`), which score cosine ≈ 1.0 against each
other. On a long-running daemon we saw 7+ operations wedged at up to 28 attempts each, an
unbounded log/CPU storm, with the already-committed queryable fact orphaned.

**Root cause:** `run_store()` applies two *admission* gates at the very top —
`EntropyGate.should_pass()` (Stage 2 is a near-duplicate dedup with a 0.95 cosine threshold
against a rolling window) and `is_low_quality()` — and returns `[]` on rejection. But
`run_store()` is also the **materialization** pipeline for an already-submitted operation. By the
time materialize runs, the operation's own queryable projection is already committed and sits in
the entropy gate's window, so the content is scored as a near-duplicate and discarded. `run_store()`
returns `[]` → `MaterializationResult((), …)` → `RuntimeError("materialization produced no final
facts")` (raised inside the materialize transaction, so it rolls back) → the operation is marked
`failed` and re-selected on every retry tick, forever.

The admission decision was already made at **submit** time (`store_fast` enforces the same
gates); re-litigating it at materialize is both wrong (it orphans a committed fact) and fatal
(the op can never complete).

## Solution

Admission gates apply to **fresh submissions only**. When `run_store()` is invoked as a
materialization pass — signalled by a non-empty `queryable_fact_ids` — skip the two early
`return []` admission gates. Materialization is a completion step for content that was already
admitted and durably committed at submit; it must finalize by promoting the existing queryable
fact, not re-admit the content.

This is a one-function change guarded by `is_materialization = bool(queryable_fact_ids)`.
The near-duplicate verdict at materialize is *expected* (the submitted projection is in the
window), so it must not be treated as a rejection.

### Alternatives Considered

| Alternative | Why rejected |
|---|---|
| Have materialize finalize with the queryable fact when `run_store()` returns `[]` | Papers over the wrong signal — a legitimate empty extraction and a spurious gate rejection become indistinguishable; also leaves the entropy window polluted with a duplicate self-embedding. |
| Reset / bypass the entropy gate's dedup window during materialize | Larger, stateful change to `EntropyGate`; risks weakening dedup for the genuine fresh-store path that shares the gate instance. |
| Move the admission gates out of `run_store()` entirely into the submit path | Correct long-term, but a much wider refactor touching every `run_store()` caller; disproportionate blast radius for this fix. The submit path (`store_fast`) already enforces admission, so gating on `queryable_fact_ids` achieves the same guarantee with a minimal diff. |

## Changes

**`src/superlocalmemory/core/store_pipeline.py`** — `run_store()` admission gates
| Change | Why |
|---|---|
| Added `is_materialization = bool(queryable_fact_ids)` | Distinguishes a materialization pass (content already admitted at submit) from a fresh store. |
| Guarded the `entropy_gate.should_pass()` early-return with `not is_materialization` | Stop the near-duplicate dedup from discarding an already-committed queryable fact at materialize. |
| Guarded the `is_low_quality()` early-return with `not is_materialization` | Same rationale for the low-quality admission gate. |

**`tests/test_core/test_canonical_ingestion_materialization.py`** — regression test
- `test_materialization_ignores_admission_gate_for_submitted_operation` — submits an operation, then patches `should_pass` to return `False` (simulating the warm-window near-duplicate verdict) and asserts materialize still reaches `COMPLETE` and promotes the queryable fact.

## What Does Not Change

- **Fresh-store admission is unchanged.** With `queryable_fact_ids` empty (all non-ingestion
  `store` / `store_fast` calls), both gates run exactly as before. Verified: the existing
  `test_ingestion_entropy_admission.py` suite still passes (fresh low-info content is still
  rejected with no durable residue).
- No API/signature changes — `run_store()` already accepted `queryable_fact_ids`.
- No config schema, CLI, or public-contract changes. No new dependencies (stdlib + existing test
  helpers only).
- Embedding / consolidation / derivation-completeness logic is untouched.

## Test Plan

**Regression test (fails before fix, passes after):**
- `tests/test_core/test_canonical_ingestion_materialization.py::test_materialization_ignores_admission_gate_for_submitted_operation`
  - **Before fix:** FAIL — `AssertionError: assert <IngestionState.FAILED: 'failed'> is <IngestionState.COMPLETE: 'complete'>` (op `last_error` = `materialization produced no final facts`)
  - **After fix:** PASS

**Existing suites (confirmed no regression), run against a clean checkout of this branch:**
- `pytest tests/test_core/test_canonical_ingestion_materialization.py tests/test_core/test_ingestion_entropy_admission.py` — 20 passed
- `pytest tests/test_core/test_ingest_gate.py tests/test_core/test_engine_store_path.py tests/test_core/test_store_pipeline_vectors.py` — green (fresh-store admission intact)

**Manual verification (production daemon):** after deploying the fix, previously-wedged
operations drained from `failed` → `complete` on the next materializer tick, and no new
`materialization produced no final facts` entries appeared.

## Breaking Changes

None.
