### PR TITLE
fix(config): Mode C load path must honour on-disk embedding model

### DIFF
--- a/src/superlocalmemory/core/config.py
+++ b/src/superlocalmemory/core/config.py
@@ -1227,9 +1227,15 @@ class SLMConfig:
                 api_key=embedding_key,
             )
         else:
+            # Honour the user's configured embedding model when present on disk.
+            # Default to the local nomic model — Mode C cannot assume the user
+            # has access to an external embeddings endpoint, and the prior
+            # default ("text-embedding-3-large") was an OpenAI cloud model name
+            # that the local sentence-transformers worker cannot resolve.
             _c_emb = EmbeddingConfig(
-                model_name="text-embedding-3-large",
-                dimension=3072,
+                model_name=embedding_model_name or "nomic-ai/nomic-embed-text-v1.5",
+                dimension=embedding_dimension or 768,
+                provider=_c_emb_provider,
                 api_endpoint=embedding_endpoint,
                 api_key=embedding_key,
                 deployment_name=embedding_deployment,

--- a/tests/test_config_system.py
+++ b/tests/test_config_system.py
@@ -73,6 +73,41 @@ def test_config_creates_parent_dirs(tmp_path):
     assert nested.exists()
 
 
+def test_mode_c_default_embedding_is_local_nomic():
+    """Mode C with no embedding overrides must default to a model the local
+    sentence-transformers worker can actually load. The prior default
+    'text-embedding-3-large' is an OpenAI cloud model name that fails on the
+    HuggingFace hub (401/RepositoryNotFound) and brings the semantic channel
+    down on every recall."""
+    config = SLMConfig.for_mode(Mode.C)
+    assert config.embedding.model_name == "nomic-ai/nomic-embed-text-v1.5"
+    assert config.embedding.dimension == 768
+
+
+def test_mode_c_honors_disk_embedding_model_name():
+    """Mode C must honour embedding_model_name passed in by load() from
+    config.json, instead of discarding it. Regression for AIDEV-86 load path:
+    the on-disk model_name was silently overwritten by the hardcoded default."""
+    config = SLMConfig.for_mode(
+        Mode.C,
+        embedding_model_name="BAAI/bge-m3",
+        embedding_dimension=1024,
+    )
+    assert config.embedding.model_name == "BAAI/bge-m3"
+    assert config.embedding.dimension == 1024
+
+
+def test_mode_c_roundtrip_preserves_local_embedding(tmp_path):
+    """Save then load a Mode C config with the default local embedding and
+    confirm the reloaded model_name matches what was on disk — not the
+    Mode C hardcoded default."""
+    config = SLMConfig.for_mode(Mode.C)
+    config.save(tmp_path / "config.json")
+    reloaded = SLMConfig.load(tmp_path / "config.json")
+    assert reloaded.embedding.model_name == "nomic-ai/nomic-embed-text-v1.5"
+    assert reloaded.embedding.dimension == 768
+
+
 def test_provider_presets_have_required_fields():
     presets = SLMConfig.provider_presets()
     for name, preset in presets.items():


### PR DESCRIPTION
SLMConfig.for_mode(Mode.C) discarded embedding_model_name and embedding_dimension on the non-OpenAI branch and hardcoded 'text-embedding-3-large' / 3072. That string is OpenAI's cloud model name; the local sentence-transformers worker resolves it as a HuggingFace repo, which returns 401/RepositoryNotFound. Every recall in Mode C then dropped the semantic, hopfield, and spreading_activation channels with the silent error 'Model load failed'.

The default for the non-OpenAI branch is now 'nomic-ai/nomic-embed-text-v1.5' (768-dim) — the same local model Modes A and B already default to — and the function now respects embedding_model_name, embedding_dimension, and embedding_provider when the loader passes them in from config.json.

This is a load-path counterpart to AIDEV-86 (dashboard write paths).