### PR TITLE
fix(proxy): strip content-encoding from upstream responses to prevent ZlibError

### DIFF
--- a/src/superlocalmemory/core/config.py
+++ b/src/superlocalmemory/core/config.py
@@ -1227,9 +1227,15 @@ class SLMConfig:
                 api_key=embedding_key,
             )
         else:
+            # Honour the user's configured embedding model when present on disk.
+            # Default to the local nomic model — Mode C cannot assume the user
+            # has access to an external embeddings endpoint, and the prior
+            # default ("text-embedding-3-large") was an OpenAI cloud model name
+            # that the local sentence-transformers worker cannot resolve.
             _c_emb = EmbeddingConfig(
-                model_name="text-embedding-3-large",
-                dimension=3072,
+                model_name=embedding_model_name or "nomic-ai/nomic-embed-text-v1.5",
+                dimension=embedding_dimension or 768,
+                provider=_c_emb_provider,
                 api_endpoint=embedding_endpoint,
                 api_key=embedding_key,
                 deployment_name=embedding_deployment,

--- a/src/superlocalmemory/optimize/proxy/_helpers.py
+++ b/src/superlocalmemory/optimize/proxy/_helpers.py
@@ -87,6 +87,9 @@ _HOP_BY_HOP = frozenset([
     "te", "trailer", "transfer-encoding", "upgrade", "host",
     "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto",
     "x-real-ip", "x-original-forwarded-for",
+    # ponytail: httpx decompresses gzip automatically; forwarding this header
+    # causes clients to double-decompress → ZlibError. Strip it here.
+    "content-encoding",
 ])
 
 _ANTHROPIC_FORWARD_HEADERS = frozenset([

--- a/tests/test_config_system.py
+++ b/tests/test_config_system.py
@@ -73,6 +73,41 @@ def test_config_creates_parent_dirs(tmp_path):
     assert nested.exists()
 
 
+def test_mode_c_default_embedding_is_local_nomic():
+    """Mode C with no embedding overrides must default to a model the local
+    sentence-transformers worker can actually load. The prior default
+    'text-embedding-3-large' is an OpenAI cloud model name that fails on the
+    HuggingFace hub (401/RepositoryNotFound) and brings the semantic channel
+    down on every recall."""
+    config = SLMConfig.for_mode(Mode.C)
+    assert config.embedding.model_name == "nomic-ai/nomic-embed-text-v1.5"
+    assert config.embedding.dimension == 768
+
+
+def test_mode_c_honors_disk_embedding_model_name():
+    """Mode C must honour embedding_model_name passed in by load() from
+    config.json, instead of discarding it. Regression for AIDEV-86 load path:
+    the on-disk model_name was silently overwritten by the hardcoded default."""
+    config = SLMConfig.for_mode(
+        Mode.C,
+        embedding_model_name="BAAI/bge-m3",
+        embedding_dimension=1024,
+    )
+    assert config.embedding.model_name == "BAAI/bge-m3"
+    assert config.embedding.dimension == 1024
+
+
+def test_mode_c_roundtrip_preserves_local_embedding(tmp_path):
+    """Save then load a Mode C config with the default local embedding and
+    confirm the reloaded model_name matches what was on disk — not the
+    Mode C hardcoded default."""
+    config = SLMConfig.for_mode(Mode.C)
+    config.save(tmp_path / "config.json")
+    reloaded = SLMConfig.load(tmp_path / "config.json")
+    assert reloaded.embedding.model_name == "nomic-ai/nomic-embed-text-v1.5"
+    assert reloaded.embedding.dimension == 768
+
+
 def test_provider_presets_have_required_fields():
     presets = SLMConfig.provider_presets()
     for name, preset in presets.items():


### PR DESCRIPTION
httpx automatically decompresses gzip responses but leaves the Content-Encoding header intact. Forwarding it to the client (Claude Code) caused double-decompression and a ZlibError on every slm wrap session start.