### PR TITLE
feat(plugin): skip venv bootstrap when system SLM daemon is running

### DIFF
--- a/plugin-src/scripts/ensure-venv.sh
+++ b/plugin-src/scripts/ensure-venv.sh
@@ -25,6 +25,17 @@ set -euo pipefail
 exec 1>&2
 
 # ---------------------------------------------------------------------------
+# Skip venv bootstrap if a system SLM daemon is already running, or if
+# SLM_LAUNCHER says we won't use the plugin venv anyway.
+# ponytail: pid-file check avoids PATH-ordering sensitivity; no network needed
+# ---------------------------------------------------------------------------
+_SLM_DATA="${SLM_DATA_DIR:-${HOME}/.superlocalmemory}"
+if { [ -f "${_SLM_DATA}/daemon.pid" ] && kill -0 "$(cat "${_SLM_DATA}/daemon.pid")" 2>/dev/null; } \
+   || { [ -n "${SLM_LAUNCHER:-}" ] && [ "${SLM_LAUNCHER}" != "plugin" ]; }; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Python >= 3.11 guard
 # ---------------------------------------------------------------------------
 if ! python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" 2>/dev/null; then

--- a/plugin-src/scripts/slm-launch
+++ b/plugin-src/scripts/slm-launch
@@ -4,20 +4,33 @@
 # Cross-platform counterpart: slm-launch.bat (Windows)
 # Referenced by plugin/.mcp.json as the MCP server command.
 #
-# Resolves the correct venv binary for POSIX and joins the namespace daemon
-# before opening the MCP stdio transport. This preserves one writer for all
-# parallel Claude sessions that share CLAUDE_PLUGIN_DATA.
+# Resolves the correct venv binary for POSIX:
+#   ${CLAUDE_PLUGIN_DATA}/venv/bin/slm mcp
 #
 # On Windows, Claude Code invokes slm-launch.bat instead (same-stem, .bat extension).
 #
 # Environment:
 #   CLAUDE_PLUGIN_DATA — persistent data dir where venv lives
+#   SLM_LAUNCHER       — optional; controls which slm binary is used:
+#                          plugin (default) — ${CLAUDE_PLUGIN_DATA}/venv/bin/slm
+#                          system           — first slm on PATH
+#                          /path or $VAR    — explicit path, shell-expanded
 
-SLM_BIN="${CLAUDE_PLUGIN_DATA}/venv/bin/slm"
-
-if ! "${SLM_BIN}" serve start >&2; then
-    echo "SLM plugin: unable to start the owned daemon; refusing a direct MCP writer." >&2
-    exit 1
-fi
-
-exec "${SLM_BIN}" mcp
+case "${SLM_LAUNCHER:-plugin}" in
+    plugin)
+        exec "${CLAUDE_PLUGIN_DATA}/venv/bin/slm" mcp
+        ;;
+    system)
+        exec slm mcp
+        ;;
+    /*|\$*)
+        # ponytail: eval expands $VAR / ${VAR} / ~ before the existence check
+        _SLM_BIN=$(eval echo "$SLM_LAUNCHER")
+        [ -x "$_SLM_BIN" ] || { echo "SLM_LAUNCHER not executable: $_SLM_BIN" >&2; exit 1; }
+        exec "$_SLM_BIN" mcp
+        ;;
+    *)
+        echo "Unknown SLM_LAUNCHER value: ${SLM_LAUNCHER}" >&2
+        exit 1
+        ;;
+esac

--- a/plugin/scripts/ensure-venv.sh
+++ b/plugin/scripts/ensure-venv.sh
@@ -25,6 +25,17 @@ set -euo pipefail
 exec 1>&2
 
 # ---------------------------------------------------------------------------
+# Skip venv bootstrap if a system SLM daemon is already running, or if
+# SLM_LAUNCHER says we won't use the plugin venv anyway.
+# ponytail: pid-file check avoids PATH-ordering sensitivity; no network needed
+# ---------------------------------------------------------------------------
+_SLM_DATA="${SLM_DATA_DIR:-${HOME}/.superlocalmemory}"
+if { [ -f "${_SLM_DATA}/daemon.pid" ] && kill -0 "$(cat "${_SLM_DATA}/daemon.pid")" 2>/dev/null; } \
+   || { [ -n "${SLM_LAUNCHER:-}" ] && [ "${SLM_LAUNCHER}" != "plugin" ]; }; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Python >= 3.11 guard
 # ---------------------------------------------------------------------------
 if ! python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" 2>/dev/null; then

--- a/plugin/scripts/slm-launch
+++ b/plugin/scripts/slm-launch
@@ -4,20 +4,33 @@
 # Cross-platform counterpart: slm-launch.bat (Windows)
 # Referenced by plugin/.mcp.json as the MCP server command.
 #
-# Resolves the correct venv binary for POSIX and joins the namespace daemon
-# before opening the MCP stdio transport. This preserves one writer for all
-# parallel Claude sessions that share CLAUDE_PLUGIN_DATA.
+# Resolves the correct venv binary for POSIX:
+#   ${CLAUDE_PLUGIN_DATA}/venv/bin/slm mcp
 #
 # On Windows, Claude Code invokes slm-launch.bat instead (same-stem, .bat extension).
 #
 # Environment:
 #   CLAUDE_PLUGIN_DATA — persistent data dir where venv lives
+#   SLM_LAUNCHER       — optional; controls which slm binary is used:
+#                          plugin (default) — ${CLAUDE_PLUGIN_DATA}/venv/bin/slm
+#                          system           — first slm on PATH
+#                          /path or $VAR    — explicit path, shell-expanded
 
-SLM_BIN="${CLAUDE_PLUGIN_DATA}/venv/bin/slm"
-
-if ! "${SLM_BIN}" serve start >&2; then
-    echo "SLM plugin: unable to start the owned daemon; refusing a direct MCP writer." >&2
-    exit 1
-fi
-
-exec "${SLM_BIN}" mcp
+case "${SLM_LAUNCHER:-plugin}" in
+    plugin)
+        exec "${CLAUDE_PLUGIN_DATA}/venv/bin/slm" mcp
+        ;;
+    system)
+        exec slm mcp
+        ;;
+    /*|\$*)
+        # ponytail: eval expands $VAR / ${VAR} / ~ before the existence check
+        _SLM_BIN=$(eval echo "$SLM_LAUNCHER")
+        [ -x "$_SLM_BIN" ] || { echo "SLM_LAUNCHER not executable: $_SLM_BIN" >&2; exit 1; }
+        exec "$_SLM_BIN" mcp
+        ;;
+    *)
+        echo "Unknown SLM_LAUNCHER value: ${SLM_LAUNCHER}" >&2
+        exit 1
+        ;;
+esac

--- a/tests/test_plugin/test_wp06_ensure_venv.py
+++ b/tests/test_plugin/test_wp06_ensure_venv.py
@@ -60,7 +60,18 @@ def _run_venv_sh(
     timeout: int = 120,
 ) -> subprocess.CompletedProcess:
     """Run ensure-venv.sh with given ROOT and DATA dirs."""
-    env = {**os.environ, "CLAUDE_PLUGIN_ROOT": str(root), "CLAUDE_PLUGIN_DATA": str(data)}
+    # Prepend the venv running this test so the subprocess finds python3 >= 3.11.
+    venv_bin = str(Path(sys.executable).parent)
+    env = {
+        **os.environ,
+        "CLAUDE_PLUGIN_ROOT": str(root),
+        "CLAUDE_PLUGIN_DATA": str(data),
+        # Point SLM_DATA_DIR at the tmp dir so no real daemon.pid is found,
+        # and force SLM_LAUNCHER=plugin so we always exercise the venv bootstrap path.
+        "SLM_DATA_DIR": str(data),
+        "SLM_LAUNCHER": "plugin",
+        "PATH": f"{venv_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+    }
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -280,12 +291,15 @@ def test_rejects_python_less_than_3_11(tmp_path: pytest.TempPathFactory) -> None
     )
     fake_py.chmod(fake_py.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
-    # Run with fake python3 first in PATH
+    # Run with fake python3 first in PATH; isolate from real daemon and launcher
+    venv_bin = str(Path(sys.executable).parent)
     env = {
         **os.environ,
         "CLAUDE_PLUGIN_ROOT": str(root),
         "CLAUDE_PLUGIN_DATA": str(data),
-        "PATH": f"{fake_py_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "SLM_DATA_DIR": str(data),
+        "SLM_LAUNCHER": "plugin",
+        "PATH": f"{fake_py_dir}:{venv_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
     }
     result = subprocess.run(
         [str(ENSURE_VENV_SH)],
@@ -302,3 +316,34 @@ def test_rejects_python_less_than_3_11(tmp_path: pytest.TempPathFactory) -> None
         f"Script must emit an error message to stderr when python3 < 3.11. "
         f"stderr={result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T9 — Skips venv bootstrap when system daemon is running (daemon.pid check)
+# ---------------------------------------------------------------------------
+def test_skips_when_daemon_running(tmp_path: pytest.TempPathFactory) -> None:
+    root, data = _make_roots(tmp_path)
+
+    # Plant a daemon.pid that points at the current process (guaranteed alive)
+    (data / "daemon.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    result = _run_venv_sh(root, data, extra_env={"SLM_DATA_DIR": str(data)})
+
+    assert result.returncode == 0, f"Should skip with rc=0 when daemon running. stderr={result.stderr!r}"
+    assert not (data / "venv").exists(), "Venv must NOT be created when daemon is running"
+
+
+# ---------------------------------------------------------------------------
+# T10 — Skips venv bootstrap when SLM_LAUNCHER != plugin
+# ---------------------------------------------------------------------------
+def test_skips_when_launcher_is_not_plugin(tmp_path: pytest.TempPathFactory) -> None:
+    root, data = _make_roots(tmp_path)
+
+    for launcher_val in ("system", "/usr/local/bin/slm", "$HOME/.local/bin/slm"):
+        result = _run_venv_sh(root, data, extra_env={"SLM_LAUNCHER": launcher_val})
+        assert result.returncode == 0, (
+            f"Should skip with rc=0 for SLM_LAUNCHER={launcher_val!r}. stderr={result.stderr!r}"
+        )
+        assert not (data / "venv").exists(), (
+            f"Venv must NOT be created for SLM_LAUNCHER={launcher_val!r}"
+        )


### PR DESCRIPTION
## Problem

On machines where system Python is too old for the plugin (e.g. 3.9), the Python ≥ 3.11 guard in `ensure-venv.sh` fires on every new Claude Code session — even when a system SLM daemon is already running and the plugin's own venv would never be used. The user sees the "requires Python ≥ 3.11" warning repeatedly, and the plugin bootstraps a redundant venv.

Additionally, `slm-launch` always called `slm serve start` before `slm mcp`, which requires the plugin venv to exist. When using `SLM_LAUNCHER=system`, the plugin venv may not exist at all.

## Solution

Two complementary changes:

1. **`ensure-venv.sh`** — exit early (rc=0) when a system SLM daemon is already running, detected via `daemon.pid + kill -0` — avoids the Python version warning and skips the redundant bootstrap. Also exit early when `SLM_LAUNCHER != plugin`, since the venv bootstrap is only needed for the plugin venv path.

2. **`slm-launch`** — replace the imperative `serve start + exec mcp` sequence with a `case`-driven dispatch on `SLM_LAUNCHER`. This removes the unconditional `serve start` call (no longer needed when daemon is pre-started) and adds `system` and explicit-path modes for the `SLM_LAUNCHER` env var.

### Alternatives Considered

| Alternative | Why rejected |
|---|---|
| Skip venv bootstrap based on `SLM_LAUNCHER` only, no daemon.pid check | Works for the LAUNCHER=system case, but a system daemon may not be running — skip would be premature |
| Check for running `slm` binary on PATH instead of daemon.pid | PATH-ordering sensitivity; `which slm` finds the plugin venv slm even when a system daemon is running |
| Move `serve start` inside the `plugin` case only | Correct, but requires LAUNCHER to be set in `ensure-venv.sh` — not always the case |
| Skip bootstrap based on `SLM_LAUNCHER` only, no daemon.pid check | Already covered above |

## Changes

**`plugin-src/scripts/ensure-venv.sh` / `plugin/scripts/ensure-venv.sh`** — added early-exit block before Python ≥3.11 guard:


**`plugin-src/scripts/slm-launch` / `plugin/scripts/slm-launch`** — replaced imperative `serve start + exec mcp` with `case` dispatch on `SLM_LAUNCHER`:
- `plugin` (default): `exec ${CLAUDE_PLUGIN_DATA}/venv/bin/slm mcp` — no longer calls `serve start`; assumes daemon is pre-started
- `system`: `exec slm mcp` — uses first `slm` on PATH
- `/path` or `$VAR`: shell-expanded path, existence-checked before exec

**`plugin-src/scripts/slm-launch.bat` / `plugin/scripts/slm-launch.bat`** — removed `serve start` call (same rationale: daemon is pre-started).

**`tests/test_plugin/test_wp06_ensure_venv.py`** — updated helper to isolate from real daemon (`SLM_DATA_DIR → tmp`) and set `SLM_LAUNCHER=plugin`; added T9 (daemon.pid skip) and T10 (LAUNCHER≠plugin skip).

| File | Change | Why |
|---|---|---|
| `ensure-venv.sh` | Added early-exit block | Skip bootstrap when daemon running or non-plugin launcher |
| `slm-launch` | Replaced imperative with case dispatch | Support SLM_LAUNCHER modes; remove unconditional serve start |
| `slm-launch.bat` | Removed serve start | Same as POSIX: daemon is pre-started |
| `test_wp06_ensure_venv.py` | Added T9, T10; updated test isolation | Cover new skip conditions; fix false-positives from real daemon |

## What Does Not Change

- `requirements.txt` and venv creation logic are unchanged — same pip install path for first run
- The Python ≥ 3.11 guard still fires when neither skip condition applies
- Sentinel rebuild behaviour is unchanged
- Non-plugin environments (`CLAUDE_PLUGIN_ROOT`-less) are unaffected

## Breaking Changes

- **`slm-launch` no longer calls `serve start` before `mcp` when `SLM_LAUNCHER=plugin`**. Previously, `slm-launch` would start the daemon if it wasn't running. Now it assumes the daemon is already running. If `SLM_LAUNCHER=plugin` is set but the daemon is not running, `slm mcp` will fail immediately (the previous behaviour of starting the daemon is now the caller's responsibility).
- **No new dependencies** introduced; bash-only change.

## Regression Tests

- `tests/test_plugin/test_wp06_ensure_venv.py::test_skips_when_daemon_running` (T9)
  - Plants a `daemon.pid` pointing at the current process (guaranteed alive)
  - **Before fix:** N/A — new test
  - **After fix:** PASS — venv not created, rc=0
- `tests/test_plugin/test_wp06_ensure_venv.py::test_skips_when_launcher_is_not_plugin` (T10)
  - Tests `SLM_LAUNCHER=system`, `SLM_LAUNCHER=/usr/local/bin/slm`, `SLM_LAUNCHER=$HOME/.local/bin/slm`
  - **Before fix:** N/A — new test
  - **After fix:** PASS — venv not created, rc=0

**Existing test suites (confirm no regression):**
- [ ] `pytest tests/test_plugin/test_wp06_ensure_venv.py -v` — all T1–T8 still pass