### PR TITLE
feat(hooks): run session close on the Stop hook

### DIFF
--- a/src/superlocalmemory/hooks/claude_code_hooks.py
+++ b/src/superlocalmemory/hooks/claude_code_hooks.py
@@ -160,13 +160,6 @@ def _wrap_python_cmd(hook_name: str) -> str:
     return command
 
 
-def _wrap_slm_cmd(slm_args: str) -> str:
-    """Wrap a generic slm CLI command with error absorption."""
-    if sys.platform == "win32":
-        return f'cmd /c "slm {slm_args} 2>NUL || exit /b 0"'
-    return f"slm {slm_args} 2>/dev/null || true"
-
-
 # ---------------------------------------------------------------------------
 # Hook definitions for settings.json
 # ---------------------------------------------------------------------------
@@ -272,7 +265,7 @@ def _hook_definitions(include_gate: bool = False) -> dict[str, list]:
                     # the git-state snapshot written by `slm hook stop`.
                     {
                         "type": "command",
-                        "command": _wrap_slm_cmd("session close"),
+                        "command": "slm session close 2>/dev/null || true",
                         "timeout": 15000,
                     },
                 ]

--- a/src/superlocalmemory/hooks/claude_code_hooks.py
+++ b/src/superlocalmemory/hooks/claude_code_hooks.py
@@ -265,7 +265,11 @@ def _hook_definitions(include_gate: bool = False) -> dict[str, list]:
                     # the git-state snapshot written by `slm hook stop`.
                     {
                         "type": "command",
-                        "command": "slm session close 2>/dev/null || true",
+                        "command": (
+                            'cmd /c "slm session close 2>NUL || exit /b 0"'
+                            if sys.platform == "win32"
+                            else "slm session close 2>/dev/null || true"
+                        ),
                         "timeout": 15000,
                     },
                 ]

--- a/src/superlocalmemory/hooks/claude_code_hooks.py
+++ b/src/superlocalmemory/hooks/claude_code_hooks.py
@@ -160,6 +160,13 @@ def _wrap_python_cmd(hook_name: str) -> str:
     return command
 
 
+def _wrap_slm_cmd(slm_args: str) -> str:
+    """Wrap a generic slm CLI command with error absorption."""
+    if sys.platform == "win32":
+        return f'cmd /c "slm {slm_args} 2>NUL || exit /b 0"'
+    return f"slm {slm_args} 2>/dev/null || true"
+
+
 # ---------------------------------------------------------------------------
 # Hook definitions for settings.json
 # ---------------------------------------------------------------------------
@@ -260,6 +267,13 @@ def _hook_definitions(include_gate: bool = False) -> dict[str, list]:
                         "type": "command",
                         "command": _wrap_python_cmd("stop_outcome"),
                         "timeout": 10000,
+                    },
+                    # Commit temporal summaries so session decisions survive beyond
+                    # the git-state snapshot written by `slm hook stop`.
+                    {
+                        "type": "command",
+                        "command": _wrap_slm_cmd("session close"),
+                        "timeout": 15000,
                     },
                 ]
             }


### PR DESCRIPTION
## Problem

The Stop hook previously only ran `slm hook stop`, which writes a git-state snapshot of session context. However, this did not commit temporal session summaries — meaning session decisions and learned patterns could be lost on session exit.

## Solution

Wire `slm session close` into the Claude Code Stop hook to commit temporal session summaries alongside the existing git-state snapshot. The command is inlined directly with error absorption (`|| true` / `|| exit /b 0`) for cross-platform compatibility, replacing the unnecessary `_wrap_slm_cmd` helper that only had one caller.

### Alternatives Considered

| Alternative | Why rejected |
|---|---|
| Keep `_wrap_slm_cmd` helper with one caller | Unnecessary abstraction for a single-use inline command — simpler to inline |
| Call `slm session close` via `_wrap_python_cmd` | `_wrap_python_cmd` is for Python functions, not CLI commands — conflates the two abstraction levels |
| Platform-agnostic shell command without the helper | Already inlined directly with `if sys.platform == "win32"` check — no helper needed |

## Changes

**`src/superlocalmemory/hooks/claude_code_hooks.py`**
- Stop hook now calls `slm session close` on session exit
  - Windows: `cmd /c "slm session close 2>/dev/null || exit /b 0"`
  - Unix: `slm session close 2>/dev/null || true`
  - Timeout: 15000ms
- Deleted `_wrap_slm_cmd` helper (only had one caller)

## What Does Not Change

- All other hook definitions unchanged
- `_wrap_python_cmd` helper untouched
- The git-state snapshot written by `slm hook stop` is unaffected

## Breaking Changes

None.

## Test Plan

**Manual verification:**
- [ ] `slm hooks install && slm hooks status` — hooks install and report correctly
- [ ] `pytest tests/test_hooks/ -v` — existing hook tests pass