### PR TITLE
fix(graph_pruner): prevent database-is-locked error in _cap_node_degree

### DIFF
--- a/src/superlocalmemory/core/graph_pruner.py
+++ b/src/superlocalmemory/core/graph_pruner.py
@@ -350,8 +350,12 @@ def _cap_node_degree(
     Algorithm (single-pass window function — no Python loops):
       1. ROW_NUMBER() OVER (PARTITION BY source_id ORDER BY weight DESC) ranks
          every edge per node in one full table scan.
-      2. Edges with rn > max_degree are deleted in a single DELETE statement.
-      Requires SQLite 3.25+ (window functions). System is on 3.53.1.
+      2. Excess edge IDs are collected in a reusable temp table.
+      3. A single DELETE statement removes them; rowcount is returned.
+      4. The temp table is created once and cleared via DELETE (not DROP) —
+         DROP TABLE acquires an EXCLUSIVE lock that conflicts with concurrent
+         writers, causing "database is locked".  Using CREATE...IF NOT EXISTS
+         plus DELETE FROM avoids that conflict while preserving rowcount.
     """
     # gi-03: cap BOTH out-degree (PARTITION BY source_id) AND in-degree
     # (PARTITION BY target_id). Previously only out-degree was capped, so hub
@@ -379,9 +383,13 @@ def _cap_node_degree(
         )
         return excess
 
-    # Step 1: collect edges exceeding the cap in either direction (one pass).
-    c.execute("DROP TABLE IF EXISTS _slm_cap_del")
-    c.execute("CREATE TEMP TABLE _slm_cap_del (edge_id TEXT PRIMARY KEY)")
+    # CREATE IF NOT EXISTS + DELETE FROM instead of DROP + CREATE.
+    # DROP TABLE acquires EXCLUSIVE which conflicts with concurrent writers.
+    # CREATE IF NOT EXISTS is idempotent; DELETE FROM clears prior contents.
+    c.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS _slm_cap_del (edge_id TEXT PRIMARY KEY)"
+    )
+    c.execute("DELETE FROM _slm_cap_del")
     c.execute(
         """
         INSERT OR IGNORE INTO _slm_cap_del (edge_id)
@@ -396,7 +404,6 @@ def _cap_node_degree(
         (profile_id, max_degree, max_degree),
     )
 
-    # Step 2: delete the over-cap edges (single DELETE).
     c.execute(
         """
         DELETE FROM graph_edges
@@ -406,8 +413,6 @@ def _cap_node_degree(
         (profile_id,),
     )
     deleted = c.rowcount
-
-    c.execute("DROP TABLE IF EXISTS _slm_cap_del")
 
     logger.info(
         "_cap_node_degree: deleted %d low-weight edges (max_degree=%d, in+out capped)",


### PR DESCRIPTION
## Problem

`prune_graph` in `src/superlocalmemory/core/graph_pruner.py` raises:

```
sqlite3.OperationalError: database is locked
```

The traceback lands in `_remove_orphan_edges` but that function's DELETE is not the cause. The lock conflict fires inside the next step — `_cap_node_degree`.

## Solution

`_cap_node_degree` executes these statements inside the `BEGIN`/`COMMIT` transaction opened at line 75:

1. `DROP TABLE IF EXISTS _slm_cap_del` — **the lock source**
2. `CREATE TEMP TABLE _slm_cap_del (...)`
3. `INSERT OR IGNORE INTO _slm_cap_del ...`
4. `DELETE FROM graph_edges WHERE edge_id IN (SELECT ... FROM _slm_cap_del)`
5. `DROP TABLE IF EXISTS _slm_cap_del`

**`DROP TABLE` acquires an EXCLUSIVE lock in SQLite.** Any concurrent writer (think-proxy daemon, CLI, another maintenance scheduler run, backup job) holding a RESERVED lock at the moment DROP fires will block until `busy_timeout` expires — then raise "database is locked". The think-proxy daemon is a persistent long-lived writer, making this collision likely in normal operation.

The fix replaces both `DROP TABLE` calls with `CREATE TEMP TABLE IF NOT EXISTS` + `DELETE FROM`:

- `CREATE TEMP TABLE IF NOT EXISTS` is idempotent and acquires no lock
- `DELETE FROM _slm_cap_del` clears the table without acquiring any lock
- The temp table is still needed because SQLite returns `c.rowcount == -1` for DELETEs inside CTEs, so the rowcount cannot be obtained via a CTE-in-DELETE approach

### Alternatives Considered

| Alternative | Why rejected |
|---|---|
| CTE-in-DELETE (single statement, no temp table) | SQLite returns `c.rowcount == -1` for DELETEs inside CTEs — breaks the `deleted = c.rowcount` return value |
| Increase `busy_timeout` further | Masks the conflict rather than eliminating it; still fails under heavy load |
| Serialize prune_graph via advisory lock | Adds complexity for a trivially avoidable lock source |

## Changes

**`src/superlocalmemory/core/graph_pruner.py`** — `_cap_node_degree()`

| Change | Why |
|---|---|
| Replace `DROP TABLE IF EXISTS _slm_cap_del` (pre-create) with `CREATE TEMP TABLE IF NOT EXISTS _slm_cap_del` | Idempotent, no EXCLUSIVE lock acquired |
| Add `DELETE FROM _slm_cap_del` after create | Clears prior contents without acquiring any lock |
| Remove trailing `DROP TABLE IF EXISTS _slm_cap_del` | Table persists for reuse across calls; no lock needed |

## What Does Not Change

- `prune_graph` public API: unchanged parameters and return type
- `graph_edges` table: no schema change
- Transaction scope and atomicity: unchanged
- `cap_degree` feature behaviour: in-degree and out-degree cap at 100 per node, unchanged

## Breaking Changes

None.

## Regression Tests

A deterministic regression test for this bug is not possible: the failure is a lock-timing race between `_cap_node_degree` and a concurrent writer (the think-proxy daemon). A synthetic test that holds a RESERVED lock on a separate thread and then calls `_cap_node_degree` would be inherently racy and flaky in CI.

Manual verification: reproduced `sqlite3.OperationalError: database is locked` consistently by running `slm prune-graph` while the think-proxy daemon was active before this fix; the error does not recur after.

Existing pruning tests confirm `_cap_node_degree` behaviour is preserved:

```
pytest tests/test_graph_integrity.py tests/core/test_pruning.py -v
...
tests/test_graph_integrity.py::TestDegreeCap::test_caps_in_degree_to_max  PASSED
tests/test_graph_integrity.py::TestDegreeCap::test_still_caps_out_degree  PASSED
tests/test_graph_integrity.py::TestAssociationOrphanPrune::test_prune_removes_orphan_association_edges  PASSED
... 6 passed in tests/test_graph_integrity.py
... 5 passed in tests/core/test_pruning.py
```

**To verify:**
```bash
pytest tests/test_graph_integrity.py tests/core/test_pruning.py -v
```

## CI Notes

CI is red for pre-existing failures unrelated to this PR. The same failures reproduce on `upstream/main` independently of this branch:

| Job | Failure | Root cause |
|---|---|---|
| `test (ubuntu-*, 3.*)` | `test_v37_release_source_has_final_package_version: assert '3.7.8' == '3.7.7'` | Release version check hardcoded to 3.7.7 after 3.7.8 shipped |
| `test (windows-latest, *)` | `test_file_created_0600: assert 438 == 384` | Unix `chmod 0o600` check; Windows does not honour POSIX permission bits |

To reproduce on main without this PR:
```bash
git checkout main
pytest tests/release/test_v37_rc_candidate_contract.py
pytest tests/optimize/proxy/test_capture.py::TestShadowCaptureRecord::test_file_created_0600
```