### PR TITLE
docs: update Python prerequisite in CONTRIBUTING.md to 3.11+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Look for issues labeled:
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.11 or higher (3.11 - 3.14)
 - SQLite3 (usually pre-installed)
 - Git
 - Text editor or IDE (VS Code, PyCharm, etc.)


### PR DESCRIPTION
## Description
This PR updates the Python version prerequisite listed in .

## Motivation
 previously listed `Python 3.8 or higher` as a prerequisite, but  requires `>=3.11,<3.15` (`requires-python = ">=3.11,<3.15"`). Updating `CONTRIBUTING.md` to state Python 3.11+ prevents setup errors for new contributors.