### PR TITLE
fix(plugin): skip ensure-venv bootstrap when daemon running or non-plugin launcher (POSIX + Windows)

### DIFF
--- a/plugin-src/scripts/ensure-venv.bat
+++ b/plugin-src/scripts/ensure-venv.bat
@@ -29,6 +29,32 @@ if not defined CLAUDE_PLUGIN_DATA (
 )
 
 :: ---------------------------------------------------------------------------
+:: Skip venv bootstrap if a system SLM daemon is already running, or if
+:: SLM_LAUNCHER indicates the plugin venv won't be used. Mirrors the same
+:: check in ensure-venv.sh (POSIX): a live daemon.pid means slm-launch will
+:: never touch this venv, so the Python >=3.11 guard below would otherwise
+:: fire needlessly (e.g. system Python 3.9 with SLM running from elsewhere).
+:: ---------------------------------------------------------------------------
+if defined SLM_DATA_DIR (
+    set "_SLM_DATA=%SLM_DATA_DIR%"
+) else (
+    set "_SLM_DATA=%USERPROFILE%\.superlocalmemory"
+)
+
+set "_DAEMON_RUNNING=0"
+if exist "%_SLM_DATA%\daemon.pid" (
+    set "_DAEMON_PID="
+    set /p _DAEMON_PID=<"%_SLM_DATA%\daemon.pid"
+    if defined _DAEMON_PID (
+        tasklist /FI "PID eq !_DAEMON_PID!" 2>nul | findstr /I "!_DAEMON_PID!" >nul
+        if not errorlevel 1 set "_DAEMON_RUNNING=1"
+    )
+)
+
+if "!_DAEMON_RUNNING!"=="1" exit /b 0
+if defined SLM_LAUNCHER if not "%SLM_LAUNCHER%"=="plugin" exit /b 0
+
+:: ---------------------------------------------------------------------------
 :: Python >= 3.11 guard
 :: ---------------------------------------------------------------------------
 python -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" 2>nul

--- a/plugin-src/scripts/ensure-venv.sh
+++ b/plugin-src/scripts/ensure-venv.sh
@@ -25,6 +25,20 @@ set -euo pipefail
 exec 1>&2
 
 # ---------------------------------------------------------------------------
+# Skip venv bootstrap if a system SLM daemon is already running, or if
+# SLM_LAUNCHER indicates the plugin venv won't be used. Both conditions mean
+# slm-launch will never touch this venv, so the Python >=3.11 guard below
+# would otherwise fire needlessly (e.g. system Python 3.9 with SLM running
+# from its own venv/install). Mirrors the daemon check in slm-launch.
+# ---------------------------------------------------------------------------
+_SLM_DATA="${SLM_DATA_DIR:-${HOME}/.superlocalmemory}"
+if { [ -f "${_SLM_DATA}/daemon.pid" ] \
+     && kill -0 "$(cat "${_SLM_DATA}/daemon.pid" 2>/dev/null)" 2>/dev/null; } \
+   || { [ -n "${SLM_LAUNCHER:-}" ] && [ "${SLM_LAUNCHER}" != "plugin" ]; }; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Python >= 3.11 guard
 # ---------------------------------------------------------------------------
 if ! python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" 2>/dev/null; then

--- a/plugin/scripts/ensure-venv.bat
+++ b/plugin/scripts/ensure-venv.bat
@@ -29,6 +29,32 @@ if not defined CLAUDE_PLUGIN_DATA (
 )
 
 :: ---------------------------------------------------------------------------
+:: Skip venv bootstrap if a system SLM daemon is already running, or if
+:: SLM_LAUNCHER indicates the plugin venv won't be used. Mirrors the same
+:: check in ensure-venv.sh (POSIX): a live daemon.pid means slm-launch will
+:: never touch this venv, so the Python >=3.11 guard below would otherwise
+:: fire needlessly (e.g. system Python 3.9 with SLM running from elsewhere).
+:: ---------------------------------------------------------------------------
+if defined SLM_DATA_DIR (
+    set "_SLM_DATA=%SLM_DATA_DIR%"
+) else (
+    set "_SLM_DATA=%USERPROFILE%\.superlocalmemory"
+)
+
+set "_DAEMON_RUNNING=0"
+if exist "%_SLM_DATA%\daemon.pid" (
+    set "_DAEMON_PID="
+    set /p _DAEMON_PID=<"%_SLM_DATA%\daemon.pid"
+    if defined _DAEMON_PID (
+        tasklist /FI "PID eq !_DAEMON_PID!" 2>nul | findstr /I "!_DAEMON_PID!" >nul
+        if not errorlevel 1 set "_DAEMON_RUNNING=1"
+    )
+)
+
+if "!_DAEMON_RUNNING!"=="1" exit /b 0
+if defined SLM_LAUNCHER if not "%SLM_LAUNCHER%"=="plugin" exit /b 0
+
+:: ---------------------------------------------------------------------------
 :: Python >= 3.11 guard
 :: ---------------------------------------------------------------------------
 python -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" 2>nul

--- a/plugin/scripts/ensure-venv.sh
+++ b/plugin/scripts/ensure-venv.sh
@@ -25,6 +25,20 @@ set -euo pipefail
 exec 1>&2
 
 # ---------------------------------------------------------------------------
+# Skip venv bootstrap if a system SLM daemon is already running, or if
+# SLM_LAUNCHER indicates the plugin venv won't be used. Both conditions mean
+# slm-launch will never touch this venv, so the Python >=3.11 guard below
+# would otherwise fire needlessly (e.g. system Python 3.9 with SLM running
+# from its own venv/install). Mirrors the daemon check in slm-launch.
+# ---------------------------------------------------------------------------
+_SLM_DATA="${SLM_DATA_DIR:-${HOME}/.superlocalmemory}"
+if { [ -f "${_SLM_DATA}/daemon.pid" ] \
+     && kill -0 "$(cat "${_SLM_DATA}/daemon.pid" 2>/dev/null)" 2>/dev/null; } \
+   || { [ -n "${SLM_LAUNCHER:-}" ] && [ "${SLM_LAUNCHER}" != "plugin" ]; }; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Python >= 3.11 guard
 # ---------------------------------------------------------------------------
 if ! python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" 2>/dev/null; then

--- a/tests/test_plugin/test_wf_windows_crossplatform.py
+++ b/tests/test_plugin/test_wf_windows_crossplatform.py
@@ -16,6 +16,9 @@ Asserts:
        on Windows → ensure-venv.bat (or a platform-aware wrapper).
   (vi) The built plugin/ contains a Windows-resolvable slm path reference
        (Scripts/slm.exe or a launcher that resolves per-OS).
+  (vii) ensure-venv.bat skips venv bootstrap when a system SLM daemon is
+        already running (daemon.pid) or SLM_LAUNCHER != plugin — Windows
+        parity with the equivalent ensure-venv.sh (POSIX) early-exit.
 
 NOTE: These tests check file existence and content; they do NOT run Windows
 binaries (tests run on macOS/Linux CI). All assertions are structural.
@@ -218,4 +221,56 @@ class TestHooksJsonCrossPlatform:
                     all_commands.append(h.get("command", ""))
         assert any("ensure-venv.sh" in cmd for cmd in all_commands), (
             f"SessionStart must still call ensure-venv.sh for POSIX. Commands: {all_commands}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (vii) ensure-venv.bat: daemon/launcher skip-check parity with ensure-venv.sh
+# ---------------------------------------------------------------------------
+class TestEnsureVenvBatSkipsWhenDaemonOrLauncherNotPlugin:
+    """ensure-venv.sh exits 0 early when a system SLM daemon is already
+    running or SLM_LAUNCHER != plugin, avoiding a needless Python >=3.11
+    guard failure on Windows hosts where the plugin venv is never used.
+    ensure-venv.bat must carry the same behaviour."""
+
+    def _bat_content(self, path: Path) -> str:
+        assert path.exists(), f"{path} not found"
+        return path.read_text(encoding="utf-8")
+
+    def test_plugin_src_bat_checks_daemon_pid(self) -> None:
+        content = self._bat_content(PLUGIN_SRC_SCRIPTS / "ensure-venv.bat")
+        assert "daemon.pid" in content, (
+            "ensure-venv.bat must check for a live daemon.pid before bootstrapping, "
+            "mirroring the ensure-venv.sh early-exit"
+        )
+
+    def test_plugin_src_bat_checks_slm_launcher(self) -> None:
+        content = self._bat_content(PLUGIN_SRC_SCRIPTS / "ensure-venv.bat")
+        assert "SLM_LAUNCHER" in content, (
+            "ensure-venv.bat must check SLM_LAUNCHER and skip bootstrap when != plugin"
+        )
+
+    def test_plugin_src_bat_exits_zero_on_skip(self) -> None:
+        content = self._bat_content(PLUGIN_SRC_SCRIPTS / "ensure-venv.bat")
+        assert "exit /b 0" in content, (
+            "ensure-venv.bat skip path must exit /b 0 (success), not fail loud"
+        )
+
+    def test_built_bat_matches_source_after_skip_check(self) -> None:
+        src = PLUGIN_SRC_SCRIPTS / "ensure-venv.bat"
+        out = PLUGIN_SCRIPTS / "ensure-venv.bat"
+        assert src.read_text(encoding="utf-8") == out.read_text(encoding="utf-8"), (
+            "plugin/scripts/ensure-venv.bat must match plugin-src/scripts/ensure-venv.bat "
+            "byte-for-byte, including the daemon/launcher skip-check"
+        )
+
+    def test_skip_check_precedes_python_guard(self) -> None:
+        """The skip-check must run BEFORE the Python >=3.11 guard, otherwise
+        the guard still fires needlessly when a system daemon is running."""
+        content = self._bat_content(PLUGIN_SRC_SCRIPTS / "ensure-venv.bat")
+        daemon_check_pos = content.find("daemon.pid")
+        python_guard_pos = content.find("Python >= 3.11 guard")
+        assert daemon_check_pos != -1 and python_guard_pos != -1
+        assert daemon_check_pos < python_guard_pos, (
+            "daemon.pid skip-check must appear before the Python >=3.11 guard in ensure-venv.bat"
         )

--- a/tests/test_plugin/test_wp06_ensure_venv.py
+++ b/tests/test_plugin/test_wp06_ensure_venv.py
@@ -60,7 +60,15 @@ def _run_venv_sh(
     timeout: int = 120,
 ) -> subprocess.CompletedProcess:
     """Run ensure-venv.sh with given ROOT and DATA dirs."""
-    env = {**os.environ, "CLAUDE_PLUGIN_ROOT": str(root), "CLAUDE_PLUGIN_DATA": str(data)}
+    env = {
+        **os.environ,
+        "CLAUDE_PLUGIN_ROOT": str(root),
+        "CLAUDE_PLUGIN_DATA": str(data),
+        # Point SLM_DATA_DIR at the tmp dir so no real daemon.pid is found, and
+        # force SLM_LAUNCHER=plugin so we always exercise the venv bootstrap path.
+        "SLM_DATA_DIR": str(data),
+        "SLM_LAUNCHER": "plugin",
+    }
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -280,11 +288,14 @@ def test_rejects_python_less_than_3_11(tmp_path: pytest.TempPathFactory) -> None
     )
     fake_py.chmod(fake_py.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
-    # Run with fake python3 first in PATH
+    # Run with fake python3 first in PATH; isolate from a real daemon and launcher
+    # so the T9/T10 skip-checks below don't mask this guard.
     env = {
         **os.environ,
         "CLAUDE_PLUGIN_ROOT": str(root),
         "CLAUDE_PLUGIN_DATA": str(data),
+        "SLM_DATA_DIR": str(data),
+        "SLM_LAUNCHER": "plugin",
         "PATH": f"{fake_py_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
     }
     result = subprocess.run(
@@ -302,3 +313,36 @@ def test_rejects_python_less_than_3_11(tmp_path: pytest.TempPathFactory) -> None
         f"Script must emit an error message to stderr when python3 < 3.11. "
         f"stderr={result.stderr!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T9 — Skips venv bootstrap when system daemon is running (daemon.pid check)
+# ---------------------------------------------------------------------------
+def test_skips_when_daemon_running(tmp_path: pytest.TempPathFactory) -> None:
+    root, data = _make_roots(tmp_path)
+
+    # Plant a daemon.pid that points at the current process (guaranteed alive)
+    (data / "daemon.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    result = _run_venv_sh(root, data, extra_env={"SLM_DATA_DIR": str(data)})
+
+    assert result.returncode == 0, (
+        f"Should skip with rc=0 when daemon running. stderr={result.stderr!r}"
+    )
+    assert not (data / "venv").exists(), "Venv must NOT be created when daemon is running"
+
+
+# ---------------------------------------------------------------------------
+# T10 — Skips venv bootstrap when SLM_LAUNCHER != plugin
+# ---------------------------------------------------------------------------
+def test_skips_when_launcher_is_not_plugin(tmp_path: pytest.TempPathFactory) -> None:
+    root, data = _make_roots(tmp_path)
+
+    for launcher_val in ("system", "/usr/local/bin/slm", "$HOME/.local/bin/slm"):
+        result = _run_venv_sh(root, data, extra_env={"SLM_LAUNCHER": launcher_val})
+        assert result.returncode == 0, (
+            f"Should skip with rc=0 for SLM_LAUNCHER={launcher_val!r}. stderr={result.stderr!r}"
+        )
+        assert not (data / "venv").exists(), (
+            f"Venv must NOT be created for SLM_LAUNCHER={launcher_val!r}"
+        )


### PR DESCRIPTION
Apologies if this PR is redundant — it appears #81 may have only been partially applied. I compared the actual file contents on `main` against that PR and found the `ensure-venv.sh` half of the fix isn't present, even though the comment on #81 says it "shipped in the 3.8 plugin launcher."

## Problem

On machines where system Python is too old for the plugin (e.g. 3.9), `ensure-venv.sh`'s Python ≥3.11 guard fires on every new Claude Code `SessionStart` — even when a system SLM daemon is already running and the plugin's own venv is never used. This is the bug described in #81.

#81 shipped the `SLM_LAUNCHER` selector and daemon-liveness check in `slm-launch` (with `eval`-based path expansion correctly replaced by `~`-only expansion for security). However, comparing `main` against that PR's diff shows the corresponding early-exit in `ensure-venv.sh` hasn't carried over:

```
$ git grep -n "daemon.pid" -- plugin plugin-src
plugin-src/scripts/slm-launch:28
plugin/scripts/slm-launch:28
```

No `daemon.pid`/`SLM_LAUNCHER` check exists in either copy of `ensure-venv.sh`, and the T9/T10 tests covering those skip conditions have no equivalent on `main` either. I checked for a tracking issue or comment explaining a deliberate deferral and found none — this looks like an oversight in the manual re-application rather than an intentional holdback.

## Proposed solution

Add the same daemon.pid + `SLM_LAUNCHER` skip-check already used in `slm-launch` to `ensure-venv.sh`, so the venv bootstrap (and its Python-version guard) is skipped whenever `slm-launch` would never touch the plugin venv anyway. No `eval`/path-expansion is needed here — the check only reads `SLM_LAUNCHER`'s value for a `!= "plugin"` comparison, not a path, so there's no equivalent security concern to the one that motivated the `slm-launch` change.

### Alternatives Considered

| Alternative | Why rejected |
|---|---|
| Check `SLM_LAUNCHER` only, skip the daemon.pid check | Doesn't help the default case where a system daemon is already running but `SLM_LAUNCHER` is unset |
| Have `slm-launch` call `ensure-venv.sh` conditionally | Larger change to the SessionStart hook wiring; the two scripts are already independently invoked, this keeps the fix local to `ensure-venv.sh` |

## Changes

**`plugin-src/scripts/ensure-venv.sh` / `plugin/scripts/ensure-venv.sh`** — added early-exit block before the Python ≥3.11 guard:

| Change | Why |
|---|---|
| Exit 0 when `${SLM_DATA_DIR:-~/.superlocalmemory}/daemon.pid` points at a live process | System daemon already running → plugin venv never used |
| Exit 0 when `SLM_LAUNCHER` is set and `!= "plugin"` | Non-plugin launcher mode never touches the plugin venv |

**`tests/test_plugin/test_wp06_ensure_venv.py`**
- `_run_venv_sh()` now sets `SLM_DATA_DIR` to the tmp data dir and `SLM_LAUNCHER=plugin` by default, so existing tests are isolated from a real daemon/launcher on the test machine
- `test_rejects_python_less_than_3_11` — same isolation added inline (it builds its own `env` dict rather than using the helper)
- Added `test_skips_when_daemon_running` (T9) — plants a `daemon.pid` pointing at the current test process (guaranteed alive), asserts rc=0 and no venv created
- Added `test_skips_when_launcher_is_not_plugin` (T10) — asserts rc=0 and no venv created for `SLM_LAUNCHER` values `system`, `/usr/local/bin/slm`, `$HOME/.local/bin/slm`

## What Does Not Change

- `slm-launch` / `slm-launch.bat` — untouched, already correct on `main`
- `requirements.txt` and venv creation/rebuild logic — unchanged
- The Python ≥3.11 guard still fires when neither skip condition applies
- Sentinel rebuild behaviour — unchanged
- No new dependencies — bash + stdlib Python test code only

## Breaking Changes

None. This only adds an early-exit path; scripts that don't set `SLM_LAUNCHER` and have no `daemon.pid` present behave exactly as before.

## Test Plan

**Regression test (fails before fix, passes after):**
- `tests/test_plugin/test_wp06_ensure_venv.py::test_skips_when_daemon_running`
  - Before: FAIL — `ensure-venv.sh` has no daemon-check, runs the Python ≥3.11 guard and attempts venv bootstrap regardless
  - After: PASS — rc=0, no venv created
- `tests/test_plugin/test_wp06_ensure_venv.py::test_skips_when_launcher_is_not_plugin`
  - Before: FAIL — same reason, `SLM_LAUNCHER` is ignored by `ensure-venv.sh`
  - After: PASS — rc=0, no venv created for all three `SLM_LAUNCHER` values tested

**Existing test suites (confirm no regression):**
- `tests/test_plugin/test_wp06_ensure_venv.py -k "skips_when or rejects_python or fails_loud or exists or executable"` — 7 passed locally (see CI Notes below for the other 4)

## CI Notes

4 of the 11 tests in this file (`test_creates_venv_on_first_run`, `test_idempotent_second_run_fast`, `test_rebuilds_on_requirements_change`, `test_truncated_sentinel_triggers_rebuild`) fail on my local machine because system `python3` is 3.9.6 here and the test harness doesn't prepend a ≥3.11 interpreter to `PATH` — this reproduces identically on a clean checkout of `main` with no changes applied, so it's a pre-existing local-environment issue unrelated to this PR, not a regression. These should pass in CI where `python3` on `PATH` is already ≥3.11.

## Duplicate/Overlap Check

Searched open PRs and issues on `qualixar/superlocalmemory` for "ensure-venv", "daemon.pid", "venv bootstrap", "SLM_LAUNCHER", "Python 3.11 warning" — no open overlap found. #81 (closed, not merged) covers the same problem statement; this PR completes the half of that fix that didn't make it to `main`.


---

## Update: Windows (`.bat`) parity

`ensure-venv.sh` (POSIX) now has the skip-check above, but `ensure-venv.bat` — the Windows equivalent, invoked by the same `SessionStart` hook on Windows hosts via same-stem `.bat` resolution — did not. Extending this PR to cover it for full cross-platform parity, since the original bug reproduces identically on Windows.

### Additional Changes

**`plugin-src/scripts/ensure-venv.bat` / `plugin/scripts/ensure-venv.bat`** — added the equivalent early-exit block before the Python ≥3.11 guard:

| Change | Why |
|---|---|
| Exit 0 when `%SLM_DATA_DIR%\daemon.pid` (default `%USERPROFILE%\.superlocalmemory\daemon.pid`) points at a live PID, checked via `tasklist /FI "PID eq ..."` | Windows equivalent of the POSIX `kill -0` liveness check |
| Exit 0 when `SLM_LAUNCHER` is set and `!= "plugin"` | Same non-plugin-launcher skip as POSIX |

No `eval`-equivalent risk here either — same rationale as the POSIX fix, this only compares `SLM_LAUNCHER`'s value, it doesn't expand a path.

**`tests/test_plugin/test_wf_windows_crossplatform.py`** — this repo's existing convention for `.bat` scripts is structural content assertions (tests run on macOS/Linux CI, not on Windows, so `.bat` files are never executed — see the file's own docstring). Added a new `TestEnsureVenvBatSkipsWhenDaemonOrLauncherNotPlugin` class following that same pattern:
- `test_plugin_src_bat_checks_daemon_pid` — asserts `daemon.pid` is referenced
- `test_plugin_src_bat_checks_slm_launcher` — asserts `SLM_LAUNCHER` is referenced
- `test_plugin_src_bat_exits_zero_on_skip` — asserts an `exit /b 0` skip path exists
- `test_built_bat_matches_source_after_skip_check` — `plugin-src`/`plugin` copies stay byte-identical (mirrors the existing `test_built_ensure_venv_bat_matches_source` convention)
- `test_skip_check_precedes_python_guard` — asserts the skip-check textually precedes the Python ≥3.11 guard

### Updated Test Plan

- `tests/test_plugin/test_wf_windows_crossplatform.py` — **20/20 passed** locally (5 new + 15 pre-existing, all still green — confirms the Windows fix doesn't disturb any existing structural assertion, e.g. byte-identical `plugin-src`/`plugin` copies, `.mcp.json` resolvability, hooks.json wiring)
- Combined with the POSIX suite: `tests/test_plugin/test_wp06_ensure_venv.py` + `tests/test_plugin/test_wf_windows_crossplatform.py` — **27 passed, 4 deselected** (the 4 deselected are the pre-existing local-environment-only failures already noted above, unrelated to this change)

### Updated What Does Not Change

- `ensure-venv.bat`'s venv creation/rebuild logic, sentinel handling, and `requirements.txt` install path — unchanged
- `slm-launch.bat` — untouched (it has no `SLM_LAUNCHER` support at all today, unaffected either way by this PR)
- No new test dependencies — structural `pathlib`/`str` assertions only, consistent with the rest of the file
