### PR TITLE
docs: finalize SuperLocalMemory V4 release truth

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -38,7 +38,7 @@ is_valid = QualixarSigner.verify(signed_output)
 
 ### Research Papers
 
-SuperLocalMemory is backed by three peer-reviewed research papers:
+SuperLocalMemory is backed by three public research preprints (arXiv preprints):
 
 1. **Paper 1 — Trust & Behavioral Foundations** (arXiv:2603.02240)
    Bayesian trust defense, behavioral pattern mining, OWASP-aligned memory poisoning protection.
@@ -47,7 +47,7 @@ SuperLocalMemory is backed by three peer-reviewed research papers:
    Fisher-Rao geodesic distance, cellular sheaf cohomology, Riemannian Langevin lifecycle dynamics.
 
 3. **Paper 3 — The Living Brain** (arXiv:2604.04514)
-   FRQAD mixed-precision metric, Ebbinghaus adaptive forgetting, 7-channel cognitive retrieval, memory parameterization, trust-weighted forgetting.
+   FRQAD mixed-precision metric, Ebbinghaus adaptive forgetting, five candidate producers plus entity-graph enhancement, memory parameterization, trust-weighted forgetting.
 
 ### Research Initiative
 
@@ -61,11 +61,11 @@ SuperLocalMemory uses the following open-source libraries:
 - NumPy (BSD-3-Clause) — Numerical operations
 - SciPy (BSD-3-Clause) — Numerical optimization (used by vCache MLE logistic refit)
 
-See [requirements.txt](requirements.txt) for the full dependency list.
+See [pyproject.toml](pyproject.toml) for the full dependency list.
 
 ### Optimize Module — Research Citations (v3.6)
 
-The Optimize module (LLD-03 / LLD-04) builds on peer-reviewed work.
+The Optimize module (LLD-03 / LLD-04) builds on cited public research.
 The Implementer verified each arXiv ID against arxiv.org before citation.
 
 | Component | Source | License / Note |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Version 4.0 hardens the full lifecycle of a memory operation — admission,
 canonical commit, projection to every store, migration, backup, and erasure —
-so each step is authorized, atomic, and verifiable. Existing memories and
-configuration are preserved; no manual migration is required.
+so each step is authorized and verifiable. Existing memories and
+configuration are preserved; M038 (eager) and M039 (deferred) migrations are
+automatically applied at startup — no manual migration is normally required
+(see `src/superlocalmemory/storage/migration_runner.py`; `slm db migrate` is
+forward-only: `status`/`--dry-run`/apply, no rollback). Schema downgrade is
+unsupported — restore a verified pre-upgrade backup instead.
 
 ### Changed
 - **MCP SDK 2.0.0 (fully-stateless Streamable HTTP).** Pinned `mcp==2.0.0`.
@@ -33,8 +37,15 @@ configuration are preserved; no manual migration is required.
   hook surfaces.
 - Every completed operation carries a durable receipt and a hash-verifiable
   completion manifest spanning all representations.
-- Backups are captured as a coherent, checksum-verified set and restored
-  atomically, rolling the live set back if any store fails mid-restore.
+- **BackupCoordinator** is available as a coherent, checksum-verified backup
+  set primitive (`src/superlocalmemory/infra/backup.py`: `BackupCoordinator.create_backup_set()` /
+  `restore_from_manifest()` — shared epoch, per-store SHA-256, manifest hash,
+  atomic publish, pre-restore snapshot + rollback). Production backup,
+  dashboard, cloud, and export routes currently use the **legacy
+  `BackupManager`** independent per-file SQLite `sqlite3.backup()` snapshots
+  (one file at a time); companion-store failures are logged as non-critical
+  and do not fail the primary `memory.db` snapshot (`_backup_all_dbs`). See
+  correction note below.
 - **SLM-Mesh** remains the peer-coordination plane (cross-session / cross-machine
   messages, locks, shared state, inbox/outbox) with mesh MCP tools on the
   `full` / `power` / `mesh` profiles.
@@ -66,9 +77,46 @@ configuration are preserved; no manual migration is required.
 - In-memory configuration changes are preserved across a save, and unknown or
   externally tuned settings survive a load/save cycle.
 
+### Backup scope and offline guidance (correction)
+
+*Correction 2026-08-08 — the 2026-08-01 text “Backups are captured as a
+coherent, checksum-verified set and restored atomically …” described the
+`BackupCoordinator` primitive, not the wired production path. The production
+path ( `BackupManager.create_backup()` / `server/routes/backup.py` /
+`maintenance_scheduler` auto-backup / cloud sync / dashboard **Export**
+) remains independent per-file `sqlite3.backup()` snapshots; this entry is
+preserved with this pointer rather than silently rewritten.*
+
+- Included stores (legacy path): `memory.db`, `learning.db`, `audit_chain.db`,
+  `code_graph.db`, `pending.db`, `audit.db` — only those present on disk; no
+  other files are backed up. `memory-*.db` is the primary snapshot;
+  `_backup_all_dbs()` copies remaining managed DBs one-by-one.
+  Companion-copy exceptions are caught and logged at `warning` as non-critical.
+  `lance/` (LanceDB directory) is **not** included by the legacy path; the
+  coherent primitive handles it as an out-of-manifest companion.
+- Exclusions: nothing outside `MANAGED_DATABASES`; no coherent epoch or
+  cross-store manifest/rollback claim for the production path.
+- Dashboard **Export** (`POST /api/backup/export`) creates a single compressed
+  `.db.gz` from the latest `memory.db` snapshot only (`memory-*.db` → gzip).
+  It is not a coherent whole-root export.
+- No `BackupCoordinator` epoch/atomic-set / whole-root backup is wired to
+  production routes or `slm` subcommands in this release.
+- Legacy backup destination files follow the process **umask**, not source-file
+  permission inheritance; there is no unwired whole-root restore route. For
+  offline whole-root backup/restore, `slm serve stop` (stop the daemon) first
+  so WAL/SHM are checkpointed, then copy the complete data-root store set
+  (all present `*.db` plus `-wal`/`-shm` sidecars and `lance/` if present)
+  with the destination directory on an encrypted/private volume; verify
+  resulting files are owner-only (`0600`/`0700`) after copy.
+- Legacy backup destination follows process umask; do not claim source
+  permission inheritance.
+
 ### Notes
-- Existing memories and configuration are preserved. No database migration is
-  required.
+- Existing memories and configuration are preserved. V4.0.0 M038 (eager) and
+  M039 (deferred) are auto-applied at startup; no manual `slm db migrate` is
+  normally required. Downgrade requires a verified pre-upgrade complete backup
+  (stop daemon before offline copy, include WAL/SHM). No `slm db migrate
+  --rollback`; use restore of that backup instead.
 
 ## [3.8.10] - 2026-07-29 — Reliable startup and MCP writes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ Look for issues labeled:
 
 ### Prerequisites
 
-- Python 3.11 or higher (3.11 - 3.14)
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux
 - SQLite3 (usually pre-installed)
 - Git
 - Text editor or IDE (VS Code, PyCharm, etc.)
@@ -162,7 +163,7 @@ superlocalmemory/
 │   │   └── migrate_cmd.py            # V2→V3 migration
 │   ├── core/                       # Core engine + config
 │   ├── storage/                    # Database layer (SQLite + sqlite-vec)
-│   ├── retrieval/                  # 7-channel retrieval
+│   ├── retrieval/                  # five candidate producers plus graph enhancement
 │   ├── dynamics/                   # EAP scheduler, SAGQ
 │   ├── math/                       # Fisher-Rao, FRQAD, Ebbinghaus, Hopfield, TurboQuant
 │   ├── encoding/                   # Embeddings, fact extraction, CCQ consolidation
@@ -171,7 +172,7 @@ superlocalmemory/
 │   ├── learning/                   # LightGBM adaptive re-ranking
 │   ├── parameterization/           # Soft prompt generation
 │   ├── hooks/                      # Claude Code hooks
-│   ├── mcp/                        # MCP server & 60 tools
+│   ├── mcp/                        # MCP server & profile-selected tools (14–87)
 │   ├── server/                     # Dashboard API server
 │   ├── code_graph/                 # Code knowledge graph (rustworkx)
 │   └── ui/                        # Dashboard frontend
@@ -673,9 +674,9 @@ See [LICENSE](LICENSE) for details.
 
 ### Project Documentation
 
-- [Architecture](ARCHITECTURE.md) - Technical design
-- [Installation](INSTALL.md) - Setup guide
-- [Quick Start](QUICKSTART.md) - First steps
+- [Architecture](docs/ARCHITECTURE.md) - Technical design
+- [Installation](docs/getting-started.md) - Setup guide
+- [Quick Start](docs/getting-started.md) - First steps
 - [Security](SECURITY.md) - Security policy
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,20 +30,39 @@ We will respond within 48 hours and provide a fix timeline within 7 days.
 #### Mode A (Zero-LLM, Local-Only)
 - All data stored at `~/.superlocalmemory/`
 - Zero cloud API calls during store/recall operations
-- No telemetry, analytics, or phone-home code
+- Mode A core store/recall operates locally without telemetry, analytics, or phone-home; optional connectors, external providers, backup destinations, and model downloads use the network only when configured
 - SQLite with WAL mode for data integrity
 
 #### Authentication
-- Optional API key authentication for dashboard/API access
-- HMAC-SHA256 timing-safe comparison
-- Rate limiting: 30 writes/min, 120 reads/min
+
+**Personal installs (`require_login = false`):** loopback owner is trusted
+without a session cookie. The install token is carried as a
+personal/API-token header (`X-SLM-Install-Token` / `Authorization:
+Bearer …`) and compared with HMAC-SHA256 timing-safe comparison.
+Rate limiting: 30 writes/min, 120 reads/min.
+
+**Enterprise installs (`require_login = true`):** the dashboard login
+flow issues an `HttpOnly` session cookie (`slm_session`; add `Secure`
+with `SLM_DASHBOARD_HTTPS=1`). Mutations require CSRF and origin
+controls in addition to the session: `Origin` must match the daemon,
+`Sec-Fetch-Site` is checked, and OAuth initiation is same-origin gated
+(`src/superlocalmemory/server/routes/backup.py`, `server/origin.py`,
+`server/rbac_enforce.py`). See `docs/rbac-teams.md`.
 
 #### Data Protection
 - Parameterized SQL queries throughout (no SQL injection)
 - XSS protection via `escapeHtml()` in all UI rendering
-- CSRF protection via token-based auth (no cookies)
 - Security headers: X-Frame-Options, CSP, X-Content-Type-Options
 - CORS whitelist with credential control
+- Secret/PII redaction before persistence and before the remote-reranker
+  trust boundary ( `src/superlocalmemory/retrieval/remote_reranker.py`:
+  `redact_secrets` + `redact_pii_text` as best-effort, not DLP); remote
+  reranker responses are bounded (8 MiB), redirects are not followed, and
+  malformed values suppress bodies without logging them. Remote *embedding*
+  (`core/embeddings.py` `_openai_compatible_embed_batch`) sends raw input
+  text with optional Bearer and does **not** apply the remote-reranker
+  HTTPS/non-loopback, userinfo/query/fragment rejections or body-suppression
+  — scope SSRF claims to the reranker path.
 
 #### Model Supply Chain (Untrusted Checkpoints)
 
@@ -63,11 +82,40 @@ Hugging Face. Two risks apply:
 Only install models from sources you trust. A malicious checkpoint can execute
 code under your user account at load time regardless of these mitigations.
 
+#### Backup and credential-at-rest caveats
+- Production backups are independent per-file `sqlite3.backup()` snapshots via
+  `BackupManager` (not a coherent cross-store epoch); companion failures are
+  non-critical. The coherent `BackupCoordinator` exists as a primitive but is
+  not wired to production/routes. Dashboard Export is `memory.db`-only gz.
+- Legacy backup destination follows process `umask`, not source-file modes;
+  place backups on an encrypted/private volume and verify `0600`/`0700`.
+- Stop the daemon (`slm serve stop`) before offline whole-root copy/restore
+  so WAL/SHM checkpoint; include sidecars and `lance/` if present.
+- Credentials: OS keychain preferred (macOS Keychain / Windows Credential
+  Locker / Linux Secret Service); fallback is owner-only plaintext
+  `~/.superlocalmemory/.credentials.json` (`0600`, `0700` parent, atomic
+  write). Provider/reranker keys persisted in `config.json` are plaintext
+  protected only by atomic `0600`; prefer env (`OPENAI_API_KEY`,
+  `SLM_CROSS_ENCODER_API_KEY`) to avoid disk persistence.
+- Feedback pseudonym: per-install keyed HMAC producing a 16-hex (64-bit)
+  `query_hash` ( `learning/feedback.py: _hash_query` ), **not encryption**;
+  within-install correlation is possible, key is `0600` beside the DB
+  (`.feedback-hash-key`, 32 bytes). Read-only data root falls back to a
+  process-local key, losing cross-restart grouping.
+
+#### Migrations (V4.0.0)
+- `M038_learning_feedback_channel` (eager) and `M039_scene_fact_members`
+  (deferred, after engine tables exist) are automatically applied at startup;
+  no manual `slm db migrate` is normally required. `slm db migrate` is
+  forward-only (`status`/`--dry-run`/apply) — no rollback. Downgrade requires
+  a verified pre-upgrade complete backup (stop daemon, whole-root copy).
+
 #### Compliance
 - GDPR Article 15 (right to access): full data export
 - GDPR Article 17 (right to erasure): complete erasure including learning data
 - EU AI Act data sovereignty: Mode A keeps all data local
 - Tamper-proof audit trail with SHA-256 hash chain
+- Bounded / content-free diagnostics export: `slm diagnostics export`
 
 ### Dependencies
 
@@ -75,11 +123,13 @@ Run `npm audit` and `pip audit` regularly. Report any findings.
 
 ### Research Foundation
 
-The security architecture is formally documented across three peer-reviewed papers:
+The SLM architecture is documented in three public arXiv preprints authored by Varun Pratap Bhardwaj (Qualixar) — these have not undergone external venue review:
 
 - **Paper 1** ([arXiv:2603.02240](https://arxiv.org/abs/2603.02240)): Bayesian trust defense, OWASP-aligned memory poisoning protection
 - **Paper 2** ([arXiv:2603.14588](https://arxiv.org/abs/2603.14588)): Information-geometric foundations, cellular sheaf cohomology for contradiction detection
 - **Paper 3** ([arXiv:2604.04514](https://arxiv.org/abs/2604.04514)): Trust-weighted forgetting, compliance audit trails, FRQAD mixed-precision integrity
+
+Supporting external work cited by SLM (for example, venues such as ICLR 2026 and Nature Scientific Reports referenced in [ATTRIBUTION.md](ATTRIBUTION.md#optimize-module--research-citations-v36) and LLD-03/LLD-04) is distinct from the three SLM preprints and should be evaluated against its own venue review.
 
 ---
 

--- a/SETUP_FOR_AGENTS.md
+++ b/SETUP_FOR_AGENTS.md
@@ -16,6 +16,13 @@ multi-session projects coherent. Cost at Mode A: zero.
 
 ---
 
+## Prerequisites
+
+- **Python:** >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- **Platforms:** Apple Silicon macOS, 64-bit Windows, 64-bit Linux
+
+---
+
 ## Setup Checklist
 
 ### Step 1 — Confirm install
@@ -23,7 +30,7 @@ multi-session projects coherent. Cost at Mode A: zero.
 ```bash
 slm --version
 ```
-Expected: `superlocalmemory 3.x.x`
+Expected: `superlocalmemory 4.0.0`
 
 On failure: `pip install superlocalmemory` then re-run.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: superlocalmemory
 description: "AI agent memory with mathematical foundations. Store, recall, search, and manage memories locally. Local data root; optional networked features have separate behavior."
-version: "3.8.0"
+version: "4.0.0"
 author: "Varun Pratap Bhardwaj"
 license: AGPL-3.0-or-later
 homepage: https://superlocalmemory.com
@@ -104,7 +104,7 @@ Every `--json` response follows a consistent envelope:
 {
   "success": true,
   "command": "recall",
-  "version": "3.0.22",
+  "version": "4.0.0",
   "data": {
     "results": [
       {"fact_id": "abc123", "score": 0.87, "content": "Alice works at Google"}
@@ -124,7 +124,7 @@ Error responses:
 {
   "success": false,
   "command": "recall",
-  "version": "3.0.22",
+  "version": "4.0.0",
   "error": {"code": "ENGINE_ERROR", "message": "Description of what went wrong"}
 }
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,8 +110,8 @@ authority to call tools, change roles, or request secrets.
 Cursor, Copilot, and Antigravity instruction files contain only
 product-authored static protocol. Dynamic memories are fetched through MCP at
 runtime and are not persisted into these high-trust files. See
-[`docs/adr/0001-untrusted-memory-boundary.md`](adr/0001-untrusted-memory-boundary.md)
-for the decision and its limits.
+`docs/adr/0001-untrusted-memory-boundary.md` (archived decision; see git history
+at `c1669e94`) for the decision and its limits.
 
 ## Three Operating Modes
 

--- a/docs/SECURITY-encryption-at-rest.md
+++ b/docs/SECURITY-encryption-at-rest.md
@@ -51,6 +51,49 @@ queries are unaffected. This is documented as an opt-in, not shipped by default.
 
 ## Backups
 
-Backups produced by the backup subsystem inherit the source file perms and
-should be written to an encrypted destination. Cloud-backup credentials are
-already written `0600` (`infra/cloud_backup.py`).
+Production backups use the legacy `BackupManager` independent per-file
+`sqlite3.backup()` snapshots — `memory.db` primary plus any present managed
+stores (`learning.db`, `audit_chain.db`, `code_graph.db`, `pending.db`,
+`audit.db`). `lance/` is not included on the legacy path (only the coherent
+`BackupCoordinator` primitive handles it as a companion). Companion-copy
+failures are logged at `warning` as non-critical. Dashboard **Export**
+(`POST /api/backup/export`, `server/routes/backup.py:export_backup`) produces
+a single gzip of the latest `memory.db` snapshot only — not a whole-root
+export.
+
+Destination permissions: backup files are created by `sqlite3` and
+`gzip.open`/`NamedTemporaryFile` and therefore **follow the process umask**,
+not source-file `0600` inheritance. Do **not** assume `0600` on the backup
+directory or its files. Place legacy backup destinations on an
+encrypted/private volume, keep the directory `0700`, and **verify** resulting
+snapshot files are owner-only (`0600`) after each backup/restore. There is no
+wired whole-root backup/restore route in this release; for offline whole-root
+copy/restore, `slm serve stop` first so WAL/SHM checkpoint, then copy the
+complete data-root store set (all present `*.db`, `-wal`/`-shm` sidecars,
+`lance/` if present). Restore is the inverse offline copy.
+
+Credentials at rest:
+- Cloud-backup credentials: OS keychain preferred; fallback is owner-only
+  plaintext `~/.superlocalmemory/.credentials.json` via `_atomic_write_creds()`
+  (`0600`, parent `0700`) — see `infra/cloud_backup.py`.
+- Provider / reranker keys persisted in `config.json`: plaintext, atomic
+  `0600` write (`core/config.py:SLMConfig.save()`) — prefer env
+  (`OPENAI_API_KEY` / `SLM_CROSS_ENCODER_API_KEY`) to avoid disk persistence.
+- Feedback HMAC key: `.feedback-hash-key` (`0600` beside `learning.db`,
+  32 bytes); produces 16-hex (64-bit) pseudonym, not encryption.
+
+## Migrations (V4.0.0)
+
+`M038_learning_feedback_channel` (eager, `learning` DB) adds the `channel`
+column for `pattern_miner` and is applied eagerly at startup.
+`M039_scene_fact_members` (deferred, `memory` DB) builds the normalized
+`scene_fact_members` projection with composite **profile-scoped**
+membership: `PRIMARY KEY (scene_id, fact_id)`, foreign keys to both
+`memory_scenes(profile_id, scene_id)` and `atomic_facts(profile_id, fact_id)`,
+covering indexes `idx_scene_fact_members_lookup (profile_id, fact_id,
+scene_id)` and `idx_scene_fact_members_order (scene_id, position)`, plus
+triggers on `memory_scenes` insert/update keeping `fact_ids_json`
+synchronized. Deferred until engine-owned tables exist; no manual
+`slm db migrate` normally required. `slm db migrate` is forward-only
+(`status`/`--dry-run`/apply) — no rollback. Downgrade requires a verified
+pre-upgrade complete backup (stop daemon, whole-root copy including sidecars).

--- a/docs/auto-memory.md
+++ b/docs/auto-memory.md
@@ -130,11 +130,17 @@ slm remember "The API rate limit on production is 500 req/min, staging is 100 re
 # Explicitly recall
 slm recall "rate limits"
 
-# Delete a memory
-slm forget --id 42
+# Delete by query (fuzzy) — preview then confirm
+slm forget "old rate limit" --dry-run
+slm forget "old rate limit" --yes
+
+# Delete a specific fact by exact ID (precise)
+slm delete QmFzZTY0RmFjdElk --yes
+slm list --limit 20   # shows fact IDs for delete/update
 ```
 
 Manual operations work regardless of auto-capture/auto-recall settings.
+`slm forget` matches by query text (fuzzy); it does not take `--id`. Use `slm delete <fact_id>` for an exact ID.
 
 ## Learning Over Time
 
@@ -173,6 +179,15 @@ connectors, cloud backup, proxy providers, dependency/model downloads, and
 other explicitly enabled integrations can use the network. Mode C sends the
 constructed model request—including selected memory evidence—to the configured
 cloud provider. Review that provider's retention and privacy terms before use.
+
+### Feedback query pseudonymization
+
+Learning feedback stores a pseudonymized grouping key, not the raw query text.
+
+- **Mechanism:** per-install keyed HMAC (`hmac.digest(key, query.encode("utf-8"), "sha256").hex()[:16]`) in `src/superlocalmemory/learning/feedback.py: _hash_query` — 16 hex characters (64-bit), **not encryption** (cannot be reversed to the query).
+- **Correlation:** within a single install, the same query text produces the same `query_hash`, so repeat-query grouping is possible; across installs the keys differ.
+- **Key storage:** 32-byte key at `.feedback-hash-key` beside the DB (`db_path.parent / ".feedback-hash-key"`), written atomically with mode `0600` (`src/superlocalmemory/learning/feedback.py: _load_or_create_hash_key`). Existing keys are re-chmodded to `0600` on load.
+- **Read-only data root fallback:** if the key cannot be persisted (for example, a read-only data root), the collector falls back to a process-local key and logs a warning; this preserves privacy but **loses cross-restart grouping** because the next process generates a new key. See `SECURITY.md` for the operational caveat.
 
 ---
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,9 +1,11 @@
-# Published V3 LoCoMo Evidence (Architecture Carried into V3.8.0)
+# Published V3 LoCoMo Evidence (Architecture Carried into V4)
 
 This page is the canonical public reference for SuperLocalMemory benchmark
-figures. It reports the published V3 architecture experiments that remain the
-foundation of V3.7. These are not a newly rerun V3.7 package benchmark and are
-not a cross-vendor leaderboard.
+figures. It reports the published V3 architecture experiments (from the
+V3 preprint / V3.7 package) that remain the foundation of V4. These are
+published V3 LoCoMo architecture evidence carried into V4 — never a newly
+rerun V4 package result — and are not a cross-vendor leaderboard. All
+original protocols are retained exactly as published.
 
 Source: [SuperLocalMemory V3 preprint (arXiv:2603.14588)](https://arxiv.org/abs/2603.14588).
 
@@ -30,6 +32,7 @@ an ablation result with its own protocol; it must not be substituted for the
 
 A LoCoMo percentage is comparable only when the conversation subset, question
 count, retrieval stack, answer-construction model, judge, and release artifact
-are declared and compatible. Do not use these figures to claim that V3.7 has
+are declared and compatible. Do not use these figures to claim that V4 has
 been freshly rerun, that every mode has the same score, or that SLM outranks a
-competitor tested under another protocol.
+competitor tested under another protocol. The architecture was introduced in V3
+and its published protocols are carried into V4 unchanged.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -102,12 +102,15 @@ Alias for `slm recall`. Same behavior, same options.
 
 ### `slm forget "query" [options]`
 
-Delete memories matching a query.
+Delete memories matching a fuzzy query (v4: `query` is positional, optional
+when used with `--dry-run`; there is **no** `slm forget --id` — use `slm
+delete <fact_id>` for exact ID deletion).
 
 ```bash
 slm forget "old staging credentials"             # Confirm before deletion
 slm forget "old staging credentials" --dry-run   # Preview only
 slm forget "old staging credentials" --yes       # Skip confirmation
+slm forget --dry-run                            # Preview all memories when no query
 ```
 
 | Option | Description |
@@ -116,7 +119,9 @@ slm forget "old staging credentials" --yes       # Skip confirmation
 | `--yes`, `-y` | Skip the confirmation prompt |
 | `--json` | Emit structured preview or mutation output |
 
-Use `slm delete <fact_id>` for precise deletion by ID.
+Use `slm delete <fact_id>` for precise deletion by ID. See
+`docs/auto-memory.md` for the same correction (fuzzy `forget`, precise
+`delete`).
 
 ### `slm delete <fact_id>`
 
@@ -178,20 +183,29 @@ Reports status of:
 
 ## Migration
 
-### `slm migrate [options]`
+### `slm migrate`
 
-Migrate a V2 database to V3 format.
+Migrate a V2 database to V3 format (one-shot; no `--dry-run`).
 
 ```bash
 slm migrate                # Run migration
-slm migrate --rollback     # Roll back when a valid migration backup exists
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--rollback` | Revert to V2 format (backup must exist) |
+> There is no `slm migrate --dry-run`, no `slm consistency` (use `slm health`
+> / `slm trace` / `slm ops`), no automatic 30-day rollback window, and the
+> migrator is not globally transactional/zero-loss — it spans file copies,
+> SQLite commits and a symlink. Verify a complete offline whole-root backup
+> (`slm serve stop` first, include WAL/SHM + `lance/` if present) before
+> migrating. Downgrade of V4 additive DBs is unsupported; see
+> `slm db migrate` below.
 
-Use `slm db migrate --dry-run` to inspect additive database migrations.
+### V4 additive DB migrations (`slm db migrate`)
+
+Current V4 ships `M038_learning_feedback_channel` (eager, `learning` DB) and
+`M039_scene_fact_members` (deferred, `memory` DB — profile-scoped composite
+`scene_fact_members` with FKs to `memory_scenes(profile_id, scene_id)` and
+`atomic_facts(profile_id, fact_id)`). Both auto-apply at startup; no manual
+migration is normally required.
 
 ## Profile Management
 
@@ -806,14 +820,15 @@ The MCP equivalents are `slm_loop_run`, `slm_loop_history`, and `slm_loop_show`.
 
 ## Database Maintenance
 
-### `slm db migrate [options]`
+### `slm db migrate [status|--dry-run]`
 
-Inspect or run additive database schema migrations.
+Inspect or run additive database schema migrations — **forward-only** (no
+`--rollback`).
 
 ```bash
-slm db migrate             # Apply pending migrations
-slm db migrate --dry-run   # Preview pending migrations
-slm db migrate --rollback  # Roll back to previous schema backup
+slm db migrate --status    # Show migration_log status (no writes)
+slm db migrate --dry-run   # Preview what would change (no writes)
+slm db migrate             # Apply pending migrations (forward-only)
 ```
 
 ### `slm db scale status|prepare|verify|promote|rollback|adopt`

--- a/docs/cloud-backup.md
+++ b/docs/cloud-backup.md
@@ -1,6 +1,14 @@
 # Cloud Backup — Google Drive & GitHub
 
-SuperLocalMemory v3.4.10+ can automatically back up your memory databases to **Google Drive** and **GitHub**. All credentials are stored in your OS keychain (macOS Keychain, Windows Credential Locker, or Linux Secret Service) — never in plaintext.
+SuperLocalMemory v3.4.10+ can automatically back up your memory databases to
+**Google Drive** and **GitHub**. Credentials are stored in your OS keychain
+(macOS Keychain, Windows Credential Locker, or Linux Secret Service) when
+available. On systems without a keychain (headless Linux, containers without
+Secret Service) they fall back to an owner-only plaintext
+`~/.superlocalmemory/.credentials.json` (`0600`, parent `0700`, atomic write
+via `_atomic_write_creds` in `src/superlocalmemory/infra/cloud_backup.py`) —
+not encrypted. Protect that file and the data root with volume encryption and
+owner-only modes; prefer a keychain-capable host when possible.
 
 ## GitHub Backup (Recommended)
 
@@ -19,24 +27,42 @@ GitHub backup works out of the box. No additional setup needed beyond a Personal
 
 That's it. SLM will:
 - Verify your token
-- Create a **private** repository (always private — your data is never public)
+- Create a **private** repository when the named repository does not exist
+- Reuse an existing repository without changing or verifying its visibility;
+  confirm that an existing backup repository is private before connecting
 - Initialize it with a README
 - Show your GitHub avatar and username in the sidebar
 
 ### How It Works
 
-- Each backup creates a **GitHub Release** with your database files as assets
-- The configured database set is included. Canonical M018 ingestion operations and raw evidence live in `memory.db`; `pending.db` is a legacy offline compatibility spool where present.
-- Only the last **5 releases** are kept — older ones are automatically deleted to prevent storage bloat
+- Each GitHub backup is an independent per-file `memory-*.db` snapshot plus
+  companion `learning-*.db` etc. when present, published as a **GitHub
+  Release** with those files as assets. Not a coherent cross-store epoch;
+  companion upload failures are non-critical for the primary `memory.db`.
+- The included stores are the `MANAGED_DATABASES` set
+  (`src/superlocalmemory/infra/backup.py`): `memory.db`, `learning.db`,
+  `audit_chain.db`, `code_graph.db`, `pending.db`, `audit.db` — only those
+  present are sent. Canonical M018 ingestion operations and raw evidence live
+  in `memory.db`; `pending.db` is a legacy offline compatibility spool where
+  present. `lance/` is not included on the legacy path.
+- Only the last **5 releases** are kept — older ones are automatically deleted
+  to prevent storage bloat
 - Backups run in the background — the dashboard never freezes
+- Snapshot files follow process `umask`; verify `0600`/`0700` on the data root
+  and any manual copy destination
 
 ### Restoring from GitHub
 
-1. Go to your `slm-backup` repo on GitHub
-2. Click **Releases** in the sidebar
-3. Download the `.db` files from the latest release
-4. Copy them to `~/.superlocalmemory/`
-5. Run `slm restart`
+1. `slm serve stop` — stop the daemon so WAL/SHM checkpoint before overwriting
+   live files
+2. Go to your `slm-backup` repo on GitHub
+3. Click **Releases** in the sidebar
+4. Download the `.db` files (plus `-wal`/`-shm` sidecars and `lance/` if you
+   saved a whole-root copy) from the latest release
+5. Copy them into `~/.superlocalmemory/` (offline replace) and verify they are
+   owner-only (`0600`/`0700`) on an encrypted/private volume
+6. Run `slm restart` (there is no wired in-place `restore` route for whole-root
+   sets in this release)
 
 ---
 
@@ -99,18 +125,27 @@ Google requires every application to register an "OAuth client" before it can ac
 
 ### How It Works
 
-- Backups are uploaded to a `SLM-Backup` folder in your Google Drive
-- Files are **replaced in-place** (no duplicates, no storage bloat)
-- ALL databases are backed up, not just memory.db
-- Your OAuth credentials are stored in your OS keychain
-- Backups run in the background
+- Backups are uploaded as independent per-file snapshots to a `SLM-Backup`
+  folder in your Google Drive; files are **replaced in-place** (no duplicates)
+- Included: `MANAGED_DATABASES` (`memory.db`, `learning.db`, `audit_chain.db`,
+  `code_graph.db`, `pending.db`, `audit.db`) — only present files are sent;
+  `lance/` is not included on the legacy path. Not a coherent epoch.
+  Companion upload failures log as non-critical and do not fail the primary.
+- OAuth credentials are stored in your OS keychain when available; otherwise
+  fallback to owner-only plaintext `.credentials.json` (`0600`, see above)
+- Backups run in the background; resulting snapshot files follow process
+  `umask` — verify `0600`/`0700` and keep the destination private/encrypted
 
 ### Restoring from Google Drive
 
-1. Open Google Drive → `SLM-Backup` folder
-2. Download all `.db` files
-3. Copy them to `~/.superlocalmemory/`
-4. Run `slm restart`
+1. `slm serve stop`
+2. Open Google Drive → `SLM-Backup` folder
+3. Download all `.db` files (plus sidecars/`lance/` if present for a whole-root
+   copy)
+4. Copy them to `~/.superlocalmemory/` and verify owner-only modes on an
+   encrypted/private volume
+5. Run `slm restart` (no wired whole-root restore route; offline copy is the
+   supported path)
 
 ---
 
@@ -130,31 +165,64 @@ Configure the schedule in **Settings** → **Backup Configuration**:
 
 ### Export
 
-Click the **download icon** in the sidebar to export a compressed `.gz` backup file you can store anywhere.
+Click the **download icon** in the sidebar to export a compressed `.gz` backup
+file. This is `POST /api/backup/export` — it creates a single gzipped
+`memory-*.db` snapshot (`memory.db`-only) via `BackupManager` and streams it as
+a temporary `*.db.gz` (removed after the response). Not a coherent whole-root
+export; for a whole-root copy stop the daemon and copy the data-root store set
+offline.
 
 ---
 
 ## What Gets Backed Up
 
-| Database | Contents | Typical Size |
-|---|---|---|
-| `memory.db` | Facts, M018 operations/raw evidence, entities, graph edges, embeddings, sessions | Deployment-specific |
-| `learning.db` | Learning signals, behavioral patterns, ranker data | 0.5 — 5 MB |
-| `audit_chain.db` | Audit trail, compliance provenance | 0.5 — 2 MB |
-| `code_graph.db` | Code knowledge graph (if used) | 0.1 — 10 MB |
-| `pending.db` | Legacy offline spool awaiting canonical M018 replay (when present) | Deployment-specific |
+| Database | Contents | Typical Size | Backup inclusion |
+|---|---|---|---|
+| `memory.db` | Facts, M018 operations/raw evidence, entities, graph edges, embeddings, sessions | Deployment-specific | Always if present (primary) |
+| `learning.db` | Learning signals, behavioral patterns, ranker data | 0.5 — 5 MB | If present via `_backup_all_dbs` (non-critical companion) |
+| `audit_chain.db` | Audit trail, compliance provenance | 0.5 — 2 MB | If present (companion, warning on failure) |
+| `code_graph.db` | Code knowledge graph (if used) | 0.1 — 10 MB | If present (companion) |
+| `pending.db` | Legacy offline spool awaiting canonical M018 replay (when present) | Deployment-specific | If present (companion) |
+| `audit.db` | Legacy audit (pre-v3.4) | — | If present (companion) |
 
-All databases are backed up using SQLite's `sqlite3.backup()` API, which creates a consistent, atomic snapshot even while the daemon is running.
+Production backups use `BackupManager`: independent per-file SQLite
+`sqlite3.backup()` snapshots, one file at a time — **not** a coherent
+cross-store epoch/manifest/atomic set. `sqlite3.backup()` creates a hot
+consistent snapshot of *that* file even while the daemon runs, but there is
+no cross-store epoch or atomic rollback across stores on the legacy path.
+`lance/` is not included on the legacy path (the coherent `BackupCoordinator`
+primitive captures it as an out-of-manifest companion, but it is not wired to
+these routes). Destination files follow process `umask`; verify `0600`/`0700`
+after copy. For offline whole-root backup/restore: `slm serve stop` first so
+WAL/SHM checkpoint, then copy the complete data-root store set.
+
+`MANAGED_DATABASES` registry: `src/superlocalmemory/infra/backup.py`.
 
 ---
 
 ## Security
 
-- **GitHub repos are always private** — hardcoded, cannot be changed
-- **Credentials stored in OS keychain** — macOS Keychain, Windows Credential Locker, or Linux Secret Service
-- **Fallback**: On systems without a keychain (headless Linux), credentials are stored in `~/.superlocalmemory/.credentials.json` with `chmod 0600` (owner-only)
+- **New GitHub backup repositories are created private.** Existing repositories
+  are reused without a visibility check or enforcement, so verify the selected
+  repository is private before uploading any memory database.
+- **Credentials — OS keychain preferred** — macOS Keychain, Windows Credential
+  Locker, or Linux Secret Service when available. **Fallback:** owner-only
+  plaintext `~/.superlocalmemory/.credentials.json` (`0600`, parent `0700`,
+  atomic `_atomic_write_creds`) on systems without a keychain (headless Linux,
+  containers) — not encrypted. Keep that file on an encrypted/private volume
+  and verify `0600`/`0700` after writes. Provider/reranker keys persisted in
+  `~/.superlocalmemory/config.json` are likewise plaintext protected only by
+  atomic `0600` (`core/config.py:SLMConfig.save()`); prefer env
+  (`OPENAI_API_KEY` / `SLM_CROSS_ENCODER_API_KEY`) to avoid disk persistence.
 - **Google OAuth tokens** are refresh tokens — they can be revoked from your [Google Account Security page](https://myaccount.google.com/permissions)
 - **GitHub PATs** can be revoked from [GitHub Settings → Tokens](https://github.com/settings/tokens)
+- **Backup destination permissions:** snapshot files follow process `umask`,
+  not `0600` inheritance — verify owner-only modes. Use an encrypted/private
+  destination for backups/exports (see `docs/SECURITY-encryption-at-rest.md`).
+  No wired whole-root restore route — offline `slm serve stop` + copy is the
+  supported restore path.
+- **No zero-loss claim for the legacy path:** per-file copies have no coherent
+  epoch; offline whole-root copy while stopped is the consistent set.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,13 +104,22 @@ slm provider set       # Interactive provider selector
 You can set keys interactively or via environment variables:
 
 ```bash
-# Interactive (stored in config file)
+# Interactive (stored in config file — plaintext, atomic 0600)
 slm provider set openai
 # Prompts: Enter your OpenAI API key: sk-...
+# File: ~/.superlocalmemory/config.json (0600; see core/config.py:SLMConfig.save)
 
-# Via environment variable (takes precedence)
+# Via environment variable (takes precedence, avoids disk persistence)
 export OPENAI_API_KEY="sk-..."
+export SLM_CROSS_ENCODER_API_KEY="..."  # for remote reranker Bearer
 ```
+
+- Interactive storage is **plaintext** protected only by an atomic `0600` write;
+  env avoids writing the secret to disk.
+- Keychain is **not** used for provider/reranker keys — those live in
+  `config.json` (`0600`) or env. Keychain (`keyring` + fallback
+  `~/.superlocalmemory/.credentials.json` `0600`) is for cloud-backup and
+  ingest credentials (`infra/cloud_backup.py`, `ingestion/credentials.py`).
 
 ## Config File
 
@@ -188,7 +197,7 @@ cannot score a Chinese, Japanese, or Arabic corpus meaningfully.
 |---------|---------|-------------|
 | `use_cross_encoder` | `true` | Master switch for reranking |
 | `cross_encoder_backend` | `""` | `""` / `"onnx"` run locally; `"openai"` / `"remote"` use `cross_encoder_endpoint` |
-| `cross_encoder_endpoint` | `""` | Full or base rerank URL. `/rerank` is appended when absent. HTTPS is required off-host; HTTP is loopback-only |
+| `cross_encoder_endpoint` | `""` | Full or base rerank URL. `/rerank` is appended when absent. HTTPS is required off-host; HTTP is loopback-only; userinfo (`user:pass@`), query strings and fragments are rejected; redirects are not followed |
 | `cross_encoder_model` | `cross-encoder/ms-marco-MiniLM-L-12-v2` | Local HF id, or the model name the endpoint serves |
 | `cross_encoder_api_key` | `""` | Optional bearer token. Prefer `SLM_CROSS_ENCODER_API_KEY`; persisted config is owner-readable (`0600`) |
 | `cross_encoder_timeout_seconds` | `15.0` | Per-request read budget for the remote endpoint |
@@ -206,11 +215,28 @@ substitute the local English model. Setting `cross_encoder_endpoint` while
 `cross_encoder_backend` is a local value is reported as a configuration error
 rather than ignored (issue #103).
 
-**Privacy boundary.** Remote reranking sends the recall query and candidate
-memory text to the configured service. SLM removes recognized secrets and PII
-before transmission, rejects URL query strings, and requires HTTPS except for
-loopback endpoints. Configure only a service you trust; keep reranking local
+**Privacy and network boundary — remote reranker
+(`src/superlocalmemory/retrieval/remote_reranker.py`).** Remote reranking
+sends the **recall query and every candidate's text** (`{model, query,
+documents}`) to the configured `cross_encoder_endpoint`. SLM applies
+`redact_secrets` + `redact_pii_text` as a **best-effort pre-transmission
+filter** (recognized secrets/PII patterns, not a DLP guarantee). The endpoint
+URL is validated: `http`/`https` only, must have a host, rejects embedded
+userinfo (`user:password@`), rejects `?query` and `#fragment` (Bearer goes in
+`Authorization`, not the URL), requires `https` for non-loopback hosts
+(`http` allowed only for `localhost`/`127.0.0.1`/`::1` etc. via
+`_is_loopback_host`), `follow_redirects=False` (3xx raises), transport + 5xx
+retry once, error bodies are suppressed ("response body suppressed"), and
+malformed value paths never log raw payloads. The Bearer token destination is
+that endpoint; configure only a service you trust and keep reranking local
 when memory text must not leave the machine.
+
+**Remote embedding runtime.** `POST /v1/embeddings` in
+`core/embeddings.py:_openai_compatible_embed_batch` sends raw `texts` as
+`{model, input: texts}` with optional `Authorization: Bearer <api_key>`. No
+remote-reranker URL hardening, no secret/PII pre-filter, and no scoped SSRF
+claim applies. The `provider="openai"` token is the generic OpenAI-compatible
+endpoint selector, not a claim of SSRF hardening.
 
 ## Environment Variables
 

--- a/docs/framework-adapters.md
+++ b/docs/framework-adapters.md
@@ -4,7 +4,7 @@
 
 Nine Python packages back their framework's native memory interface with the local SLM data root. Install alongside the target framework; all data stays in the configured data root unless an optional SLM provider, connector, or backup feature is explicitly enabled.
 
-**Prerequisites:** Python 3.11+, SuperLocalMemory V4 installed in the same environment.
+**Prerequisites:** SuperLocalMemory V4, Python >=3.11,<3.15, supported Apple Silicon macOS / 64-bit Windows / 64-bit Linux.
 
 ---
 

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -1,5 +1,7 @@
 # Installing SuperLocalMemory on Linux
 
+> **V4 Linux support:** SuperLocalMemory V4 supports 64-bit Linux only. Packaging metadata does not hard-block unsupported architectures; unsupported platforms fail at runtime dependency resolution rather than at install metadata.
+
 SuperLocalMemory requires Python 3.11–3.14. Installation code and durable memory
 data have separate ownership: installers manage the executable environment;
 `SLM_DATA_DIR` selects memory data. No supported installer moves or deletes data.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -223,6 +223,8 @@ Report whether a recalled memory was useful. Trains the adaptive ranker over tim
 | `feedback` | string | No | `"relevant"`, `"irrelevant"`, or `"partial"` (default: `"relevant"`) |
 | `query` | string | No | The original query that surfaced this memory |
 
+If `query` is provided, the collector stores only a pseudonymized grouping key, not the raw text: per-install keyed HMAC `hmac.digest(key, query.encode("utf-8"), "sha256").hex()[:16]` (16 hex / 64-bit, `src/superlocalmemory/learning/feedback.py: _hash_query`), **not encryption**. Within a single install the same query yields the same `query_hash` (repeat correlation); across installs keys differ. The 32-byte key is at `.feedback-hash-key` beside the DB, mode `0600` (`_load_or_create_hash_key`); a read-only data root falls back to a process-local key and loses cross-restart grouping.
+
 ### `close_session`
 
 Close the current session and create temporal summary events. Aggregates session facts into per-entity summaries.

--- a/docs/migration-from-v2.md
+++ b/docs/migration-from-v2.md
@@ -2,7 +2,24 @@
 > SuperLocalMemory V4 Documentation
 > https://superlocalmemory.com | Part of Qualixar
 
-Upgrade from SuperLocalMemory V2 to V3. Zero data loss, one command, rollback available.
+Upgrade from SuperLocalMemory V2 to V3. Verify backup before migrating; see
+rollback caveats below. No `slm migrate --dry-run` exists.
+
+> **V4.0.0 additive migrations:** V4.0.0 includes `M038_learning_feedback_channel`
+> (eager, applied at startup on `learning.db`) and `M039_scene_fact_members`
+> (deferred, applied once engine-owned tables exist on `memory.db`). Manual
+> `slm db migrate` is not normally required for V4.0.0 itself. `slm db migrate` is
+> **forward-only** (`status` / `--dry-run` / apply; no `slm db migrate
+> --rollback` and no `slm migrate --rollback` for V4 DBs — see
+> `src/superlocalmemory/cli/db_migrate.py` and
+> `src/superlocalmemory/storage/migration_runner.py`). It refuses to run
+> against a DB written by a newer build and holds back migrations whose
+> dependency did not complete. Schema downgrade is unsupported — to revert a V4
+> upgrade, restore a **verified pre-upgrade complete backup of the whole data
+> root** ( `slm serve stop` first so WAL/SHM checkpoint, then copy all present
+> `*.db` plus `-wal`/`-shm` sidecars and `lance/` if present). The `M039`
+> projection is `scene_fact_members` with **profile-scoped composite**
+> membership (see `src/superlocalmemory/storage/migrations/M039_scene_fact_members.py`).
 
 ---
 
@@ -14,7 +31,7 @@ Upgrade from SuperLocalMemory V2 to V3. Zero data loss, one command, rollback av
 | **Modes** | One mode (cloud required for smart features) | Three modes: A (zero-cloud), B (local LLM), C (cloud LLM) |
 | **Math layer** | None | Fisher-Rao similarity, Sheaf consistency, Langevin lifecycle |
 | **Ingestion** | Basic text storage | 11-step pipeline: entities, facts, emotions, beliefs, graph, and more |
-| **Data directory** | `~/.superlocalmemory/` | `~/.superlocalmemory/` (symlink preserves old path) |
+| **Data directory** | `~/.claude-memory/` | `~/.superlocalmemory/` (`~/.claude-memory/` symlink preserves old path) |
 | **Consistency** | Manual | Automatic contradiction detection |
 | **Recall quality** | Good | Significantly better on complex queries (multi-hop, temporal) |
 
@@ -32,16 +49,25 @@ npm update -g superlocalmemory
 
 ```bash
 slm --version
-# Should show 3.x.x
+# Should show 3.x.x or 4.x.x
 ```
 
-3. **(Optional) Preview changes:**
+3. **Verify a complete pre-upgrade backup exists** (do not rely on a live
+   `memory.db` copy):
 
 ```bash
-slm migrate --dry-run
+slm serve stop
+# Copy the complete data root to an encrypted/private destination and verify
+# owner-only modes (0600/0700). See docs/cloud-backup.md and
+# docs/SECURITY-encryption-at-rest.md. Destination follows process umask —
+# do not assume 0600 inheritance.
+ls -l ~/.superlocalmemory/backups/
+slm serve start
 ```
 
-This shows exactly what will change without modifying anything.
+> No `slm migrate --dry-run` exists for the V2→V3 migrator. For V4 additive
+> DB migrations the inspect command is `slm db migrate --dry-run` (and
+> `slm db migrate --status`), forward-only.
 
 ## Run the Migration
 
@@ -51,15 +77,23 @@ slm migrate
 
 The migration:
 
-1. Creates a full backup of your V2 database
-2. Moves data from `~/.superlocalmemory/` to `~/.superlocalmemory/`
-3. Creates a symlink (`~/.superlocalmemory/ -> ~/.superlocalmemory/`) so old IDE configs still work
+1. Creates a backup of your V2 database (verify it is complete and
+   owner-only before proceeding)
+2. Copies data from `~/.claude-memory/` to `~/.superlocalmemory/`
+3. Creates a symlink (`~/.claude-memory/ -> ~/.superlocalmemory/`) so old IDE configs still work
 4. Extends the database schema with V3 tables (15 new tables)
 5. Re-indexes existing memories for multi-producer retrieval
 6. Sets Mode A as default (zero breaking changes)
 7. Verifies integrity
 
-**Duration:** Under 30 seconds for most databases. Large databases (10,000+ memories) may take 1-2 minutes.
+> Duration: under 30 s for most databases; 10 000+ memories may take 1–2 min.
+> The migration spans file copies, SQLite commits, and a rename/symlink — not a
+> single global transaction. Do **not** treat it as globally
+> transactional/zero-loss without a verified pre-upgrade backup.
+
+**V4 migrations after that:** `M038` (adds `learning_feedback.channel` for
+`pattern_miner`) and the deferred `M039` normalized scene/fact projection are
+applied automatically; see header note for DDL details.
 
 ## What Gets Preserved
 
@@ -91,14 +125,15 @@ These are computed from your existing memories during migration.
 ### Verify
 
 ```bash
-slm status
+slm status --json
+# or slm status for the text summary
+slm db migrate --status   # shows M038/M039 applied state: see docs/cli-reference.md
 ```
 
 Confirm:
 - Mode shows `A` (default after migration)
-- Memory count matches your V2 count
-- Health shows all green
-- Profile is your previous active profile
+- Memory count matches your V2 count (`slm status --json | jq '.data.fact_count'`)
+- `slm db migrate --status` shows expected migrations as applied/verified
 
 ### Try a recall
 
@@ -113,21 +148,27 @@ Results should match or exceed V2 quality. V3's multi-producer retrieval finds m
 ```bash
 slm trace "your query"       # See channel-by-channel breakdown
 slm health                   # Check math layer status
-slm consistency              # Run contradiction detection
 slm mode b                   # Try local LLM mode (if Ollama installed)
+# Use slm db migrate --status / --dry-run to inspect additive DB migrations
+# (forward-only; no rollback). See `slm ops status` / `slm ops list` for
+# stuck operations after upgrades.
 ```
 
 ## Rollback
 
-If anything goes wrong, roll back within 30 days:
+Rollback of the V2→V3 `slm migrate` is **only** possible while a valid
+pre-migration backup still exists and is **not** automatic or retained for
+30 days. There is no automatic 30-day retention or timed deletion — verify the
+backup file before migrating. Re-creating the backup during migration does not
+guarantee a coherent cross-store set on the legacy per-file path
+(`docs/cloud-backup.md`).
 
-```bash
-slm migrate --rollback
-```
-
-This restores your V2 database from the backup created during migration. The symlink is removed and the original `~/.superlocalmemory/` directory is restored.
-
-**After 30 days:** The backup is automatically cleaned up. If you need to roll back after 30 days, restore from your own backups.
+Downgrade of a V4 DB (M038/M039) is **unsupported**: there is no
+`slm db migrate --rollback` (and no `slm migrate --rollback` for V4 DBs).
+To revert a V4 upgrade, restore a verified **pre-upgrade complete backup of
+the whole data root** (stop the daemon first — `slm serve stop` — and include
+WAL/SHM sidecars plus `lance/` if present). Copying a live `memory.db` alone
+while the daemon runs is unsafe and does not guarantee a coherent restore set.
 
 ## IDE Configuration Updates
 
@@ -151,13 +192,17 @@ This updates all detected IDE configs to point to `~/.superlocalmemory/` instead
 No. The symlink ensures old paths still work. Your IDE will not notice the change.
 
 **Q: Do I need to reconfigure my API keys?**
-No. API keys are migrated to the new config location automatically.
+No. API keys are migrated to the new config location automatically (plaintext
+`0600` in `config.json` — prefer env if you want to avoid disk persistence).
 
 **Q: Can I run V2 and V3 side by side?**
-No. The migration converts your database in place (with backup). Use `--rollback` if you want to return to V2.
+No. The migration converts your database in place (with backup). No side-by-side.
 
 **Q: What if migration fails halfway?**
-The migration is transactional. If any step fails, everything is rolled back automatically. Your V2 data remains untouched.
+The migration spans multiple file copies/SQLite commits and a symlink; it is **not**
+a globally atomic/transactional switch. Keep the verified pre-upgrade complete
+backup (offline whole-root copy with daemon stopped) and restore that if needed.
+Do not rely on an unverified live `memory.db` copy.
 
 **Q: I have multiple profiles. Are they all migrated?**
 Yes. All profiles are migrated together. Profile isolation is preserved.

--- a/docs/optimize-per-agent.md
+++ b/docs/optimize-per-agent.md
@@ -49,4 +49,4 @@ does. On Codex, cache/compress works through the MCP tools plus the
 
 ---
 
-SuperLocalMemory v3.8.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory V4.0.0 · Qualixar · AGPL-3.0-or-later

--- a/docs/rbac-teams.md
+++ b/docs/rbac-teams.md
@@ -73,27 +73,40 @@ After restart, the dashboard prompts for credentials. Session cookies are
 
 ### Via CLI
 
+The `slm profile` CLI manages workspace profiles only — not users:
+
 ```bash
-# List users in the active profile
-slm profile users list
-
-# Create a user
-slm profile users create alice --role member
-
-# Set role
-slm profile users role alice admin
-
-# Remove user from workspace
-slm profile users remove alice
+slm profile list              # list workspaces
+slm profile switch <name>     # switch active workspace
+slm profile create <name>     # create a new workspace
 ```
+
+Verified in `src/superlocalmemory/cli/main.py`: `profile` accepts only `list | switch | create` (`choices=["list", "switch", "create"]`). There is no `slm profile users …` subcommand. User and membership administration is via the RBAC HTTP API and the dashboard (see below).
 
 ### Via dashboard
 
 The **Governance → Access & Users** tab shows the user list for the current workspace. Admins can invite, assign roles, and remove users.
 
-### Via MCP
+### Via HTTP API (RBAC routes in `src/superlocalmemory/server/routes/rbac.py`)
 
-For automated provisioning, use the REST API (HTTP MCP endpoint). The RBAC API requires an admin session token.
+All routes are under `/api/rbac/*` and require machine auth (`require_http_mutation_actor`); user/membership/policy admin further requires `MANAGE` (`src/superlocalmemory/server/rbac_enforce.py: require_manage`).
+
+| Method & Path | Purpose |
+|---|---|
+| `POST /api/rbac/login` | Authenticate; sets `HttpOnly` `slm_session` cookie (add `Secure` with `SLM_DASHBOARD_HTTPS=1`) |
+| `POST /api/rbac/logout` | Revoke session |
+| `GET /api/rbac/whoami` | Current principal |
+| `GET /api/rbac/status` | `rbac_active`, `require_login`, `user_count` |
+| `GET /api/rbac/users` | List users (MANAGE) |
+| `POST /api/rbac/users` | Create user; optional `role` + `profile_id` to set initial membership (requires MANAGE on that profile) |
+| `PATCH /api/rbac/users/{user_id}` | Update `display_name`, `password`, `status` |
+| `DELETE /api/rbac/users/{user_id}` | Delete user |
+| `GET /api/rbac/members?profile_id=` | List workspace members (MANAGE on target profile) |
+| `POST /api/rbac/members` `{user_id, role, profile_id}` | Set membership role (`admin`/`member`/`viewer`) |
+| `DELETE /api/rbac/members` `{user_id, profile_id}` | Remove membership |
+| `POST /api/rbac/policy` `{require_login}` | Toggle login gate |
+
+Workspace membership commands require `MANAGE` on the **target** profile, and modifying a user other than yourself requires authority over that user (owner or an admin who shares a `MANAGE` workspace).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -265,14 +265,25 @@ Each IDE has its own MCP config file. They do not conflict. All IDEs share the s
 
 Extremely rare with SQLite WAL mode, but if it happens:
 
-```bash
-# Check integrity
-slm status --json
+1. **Stop the daemon first** — a live `cp` of `memory.db` alone is unsafe (WAL/SHM may be uncheckpointed and companion stores diverge):
 
-# Restore from automatic backup
-ls ~/.superlocalmemory/backups/
-cp ~/.superlocalmemory/backups/memory-2026-03-15.db ~/.superlocalmemory/memory.db
-```
+   ```bash
+   slm serve stop
+   ```
+
+2. **Restore a complete, verified data-root/store-set backup** taken with the daemon stopped. Include `memory.db` plus sidecars (`memory.db-wal`, `memory.db-shm`) and any present `lance/` or other store directories — not a single-file `cp` over a running daemon. Backups taken via `BackupManager` are per-file `sqlite3.backup()` snapshots; a coherent offline copy is a whole-root copy with the daemon stopped so WAL checkpoints (see `SECURITY.md` Backup and credential-at-rest caveats).
+
+3. **Verify the restore** before restarting:
+
+   ```bash
+   slm status --json
+   sqlite3 ~/.superlocalmemory/memory.db "PRAGMA integrity_check;"
+   ls -l ~/.superlocalmemory/memory.db* ~/.superlocalmemory/lance 2>&1 | head -20
+   slm serve start
+   slm status --json
+   ```
+
+   Do not rely on `slm migrate --rollback` for schema downgrade — `slm db migrate` is **forward-only** (`status`/`--dry-run`/apply, no rollback) and there is no supported downgrade path except restoring a verified pre-upgrade complete backup.
 
 ### Database is too large
 

--- a/ide/integrations/agent-framework/README.md
+++ b/ide/integrations/agent-framework/README.md
@@ -2,7 +2,7 @@
 
 [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/)
 memory + history providers backed by the local data root of
-[SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+[SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 Give an Agent Framework agent durable conversation history and memory
 enrichment in your local SLM data root, visible through every other SLM
@@ -11,9 +11,10 @@ separate network behavior.
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same environment
 - `agent-framework-core >= 1.5.0` (the release that introduced `before_run` / `after_run`)
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -78,6 +79,6 @@ AGPL-3.0 — see [LICENSE](../../../LICENSE).
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/)

--- a/ide/integrations/autogen/README.md
+++ b/ide/integrations/autogen/README.md
@@ -1,7 +1,7 @@
 # autogen-superlocalmemory
 
 AutoGen [`Memory`](https://microsoft.github.io/autogen/) backed by the local
-data root of [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+data root of [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 Give an AutoGen agent durable memory stored in your local SLM data root and
 visible through every other SLM surface (CLI, MCP, dashboard). Records stay in
@@ -15,9 +15,10 @@ downloads have separate network behavior.
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same environment
 - `autogen-agentchat >= 0.7.5` (pulls `autogen-core` as a dependency)
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -82,7 +83,7 @@ AGPL-3.0 — see [LICENSE](../../../LICENSE).
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [AutoGen](https://microsoft.github.io/autogen/)
 - [Microsoft Agent Framework adapter](../agent-framework/)

--- a/ide/integrations/crewai/README.md
+++ b/ide/integrations/crewai/README.md
@@ -1,7 +1,7 @@
 # crewai-superlocalmemory
 
 CrewAI [`StorageBackend`](https://docs.crewai.com/) (memory storage) backed by
-the local data root of [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+the local data root of [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 Give a CrewAI agent or crew durable, scope-aware memory stored in your local
 SLM data root and visible through every other SLM surface (CLI, MCP,
@@ -10,9 +10,10 @@ connectors, backup, and downloads have separate network behavior.
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same environment
 - `crewai >= 1.14.6`
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -82,6 +83,6 @@ AGPL-3.0 — see [LICENSE](../../../LICENSE).
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [CrewAI](https://docs.crewai.com/)

--- a/ide/integrations/google-adk/README.md
+++ b/ide/integrations/google-adk/README.md
@@ -2,7 +2,7 @@
 
 Google ADK [`BaseMemoryService`](https://google.github.io/adk-docs/) backed by
 the local data root of
-[SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+[SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 Give a Google ADK agent durable session memory stored in your local SLM data
 root and visible through every other SLM surface (CLI, MCP, dashboard).
@@ -11,9 +11,10 @@ backup, and downloads have separate network behavior).
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same environment
 - `google-adk >= 2.5.0`
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -79,6 +80,6 @@ AGPL-3.0 — see [LICENSE](../../../LICENSE).
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [Google ADK](https://google.github.io/adk-docs/)

--- a/ide/integrations/langchain/README.md
+++ b/ide/integrations/langchain/README.md
@@ -1,14 +1,15 @@
 # langchain-superlocalmemory
 
-LangChain chat message history backed by the local data root of [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+LangChain chat message history backed by the local data root of [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 This adapter writes chat messages to the configured SLM data root. Optional SLM providers, connectors, backup, and downloads have separate network behavior.
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same Python environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same Python environment
 - `langchain-core >= 1.0.0`
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -86,7 +87,7 @@ history = SuperLocalMemoryChatMessageHistory(
 
 ## How It Works
 
-Each LangChain message is submitted through SuperLocalMemory V3's canonical
+Each LangChain message is submitted through SuperLocalMemory V4.0.0's canonical
 ingestion contract. The exact serialized message remains in the parent memory
 row for lossless chat-history round trips, while SLM builds searchable facts:
 
@@ -104,6 +105,6 @@ AGPL-3.0 -- see [LICENSE](../../../LICENSE) for details.
 
 ## Links
 
-- [SuperLocalMemory V3 Repository](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0 Repository](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [LangChain Documentation](https://python.langchain.com/)

--- a/ide/integrations/langgraph/README.md
+++ b/ide/integrations/langgraph/README.md
@@ -2,7 +2,7 @@
 
 LangGraph [`BaseStore`](https://langchain-ai.github.io/langgraph/) (long-term
 memory) backed by the local data root of
-[SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+[SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 Give a LangGraph agent durable, namespaced long-term memory stored in your
 local SLM data root and visible through every other SLM surface (CLI, MCP,
@@ -11,9 +11,10 @@ separate network behavior.
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same environment
 - `langgraph >= 1.0.0`
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -88,6 +89,6 @@ AGPL-3.0 — see [LICENSE](../../../LICENSE).
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [LangGraph](https://langchain-ai.github.io/langgraph/)

--- a/ide/integrations/llamaindex/README.md
+++ b/ide/integrations/llamaindex/README.md
@@ -1,11 +1,12 @@
-# LlamaIndex Chat Store — SuperLocalMemory V3
+# LlamaIndex Chat Store — SuperLocalMemory V4.0.0
 
-A LlamaIndex `BaseChatStore` integration for [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+A LlamaIndex `BaseChatStore` integration for [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 ## Prerequisites
 
-- Python 3.11+
-- SuperLocalMemory installed in the same Python virtual environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same Python virtual environment
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ```bash
 python -m pip install superlocalmemory
@@ -60,7 +61,7 @@ chat_store.delete_messages("session-1")
 
 ## How It Works
 
-Each chat message is submitted through SuperLocalMemory V3's canonical ingestion
+Each chat message is submitted through SuperLocalMemory V4.0.0's canonical ingestion
 contract. The exact serialized payload remains available for chat-store round trips:
 - **Content**: JSON-serialized `{role, content, additional_kwargs}`
 - **Session**: `llamaindex:<sha256(session_key)>` for bounded, injection-safe isolation
@@ -77,6 +78,6 @@ chat_store = SuperLocalMemoryChatStore(db_path="/path/to/custom/memory.db")
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [LlamaIndex Documentation](https://docs.llamaindex.ai/)
 - [LlamaIndex Chat Stores Guide](https://docs.llamaindex.ai/en/stable/module_guides/storing/chat_stores/)

--- a/ide/integrations/openai-agents/README.md
+++ b/ide/integrations/openai-agents/README.md
@@ -3,7 +3,7 @@
 OpenAI Agents SDK
 [`SessionABC`](https://openai.github.io/openai-agents-python/) (conversation
 history store) backed by the local data root of
-[SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+[SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 Give an OpenAI Agents SDK runner durable, ordered conversation history stored
 in your local SLM data root and visible through every other SLM surface (CLI,
@@ -12,9 +12,10 @@ providers, connectors, backup, and downloads have separate network behavior).
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same environment
 - `openai-agents >= 0.18.3`
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -84,6 +85,6 @@ AGPL-3.0 — see [LICENSE](../../../LICENSE).
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)

--- a/ide/integrations/semantic-kernel/README.md
+++ b/ide/integrations/semantic-kernel/README.md
@@ -2,7 +2,7 @@
 
 [Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/) vector
 store (`VectorStoreCollection`) backed by the local data root of
-[SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory).
+[SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory).
 
 Give a Semantic Kernel agent a record store for memory in your local SLM data
 root, visible through every other SLM surface (CLI, MCP, dashboard). Optional
@@ -10,9 +10,10 @@ SLM providers, connectors, backup, and downloads have separate network behavior.
 
 ## Prerequisites
 
-- Python 3.11+
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory) installed in the same environment
+- Python >=3.11,<3.15 (3.11, 3.12, 3.13, 3.14)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory) installed in the same environment
 - `semantic-kernel >= 1.34.0` (the post-1.34 vector-store API)
+- Supported platforms: Apple Silicon macOS, 64-bit Windows, 64-bit Linux — Intel Mac and 32-bit Windows (Win32) are outside the V4.0.0 support contract (`cryptography==50.0.0` has no wheel for those architectures).
 
 ## Installation
 
@@ -77,6 +78,6 @@ AGPL-3.0 — see [LICENSE](../../../LICENSE).
 
 ## Links
 
-- [SuperLocalMemory V3](https://github.com/qualixar/superlocalmemory)
+- [SuperLocalMemory V4.0.0](https://github.com/qualixar/superlocalmemory)
 - [Documentation](https://superlocalmemory.com/)
 - [Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/)

--- a/src/superlocalmemory/cli/commands.py
+++ b/src/superlocalmemory/cli/commands.py
@@ -1908,7 +1908,7 @@ def cmd_status(args: Namespace) -> None:
         ])
         return
 
-    print("SuperLocalMemory V3")
+    print("SuperLocalMemory V4")
     print(f"  Mode: {config.mode.value.upper()}")
     print(f"  Provider: {config.llm.provider or 'none'}")
     print(
@@ -2275,7 +2275,7 @@ def cmd_help(args: Namespace) -> None:
         return
 
     from superlocalmemory.cli.json_output import _get_version
-    print(f"SuperLocalMemory V3 ({_get_version()}) — command overview")
+    print(f"SuperLocalMemory V4 ({_get_version()}) — command overview")
     print("=" * 58)
     print("Run any command with -h for its options, e.g.  slm recall -h\n")
     for title, rows in _COMMAND_GROUPS:
@@ -2322,7 +2322,7 @@ def cmd_doctor(args: Namespace) -> None:
             print(line)
 
     if not use_json:
-        print("SuperLocalMemory V3 — Doctor (Pre-flight Check)")
+        print("SuperLocalMemory V4 — Doctor (Pre-flight Check)")
         print("=" * 50)
         print()
 
@@ -2978,7 +2978,7 @@ def cmd_warmup(_args: Namespace) -> None:
     """
     import superlocalmemory.core.embeddings as _emb_mod
 
-    print("SuperLocalMemory V3 — Embedding Model Warmup")
+    print("SuperLocalMemory V4 — Embedding Model Warmup")
     print("=" * 50)
     print(f"  Python: {sys.executable}")
     print(f"  Model:  nomic-ai/nomic-embed-text-v1.5 (~500MB)")
@@ -3088,7 +3088,7 @@ def cmd_dashboard(args: Namespace) -> None:
 
     port = getattr(args, "port", None) or _get_port()
 
-    print("  SuperLocalMemory V3 — Web Dashboard")
+    print("  SuperLocalMemory V4 — Web Dashboard")
     print(f"  Starting daemon if needed...")
 
     if not ensure_daemon(port=port):

--- a/src/superlocalmemory/cli/main.py
+++ b/src/superlocalmemory/cli/main.py
@@ -179,7 +179,7 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(
         prog="slm",
-        description=f"SuperLocalMemory V3 ({_ver}) — AI agent memory with mathematical foundations",
+        description=f"SuperLocalMemory V4 ({_ver}) — AI agent memory with mathematical foundations",
         epilog=_HELP_EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -519,7 +519,7 @@ def main() -> None:
     sub.add_parser("mcp", help="Start MCP server (stdio transport for IDE integration)")
     sub.add_parser("warmup", help="Pre-download embedding model (~500MB, one-time)")
 
-    dashboard_p = sub.add_parser("dashboard", help="Open 17-tab web dashboard")
+    dashboard_p = sub.add_parser("dashboard", help="Open web dashboard")
     dashboard_p.add_argument(
         "--port", type=int, default=8765, help="Port (default 8765)",
     )

--- a/src/superlocalmemory/cli/setup_wizard.py
+++ b/src/superlocalmemory/cli/setup_wizard.py
@@ -410,7 +410,7 @@ def run_wizard(auto: bool = False) -> None:
 
     print()
     print("╔══════════════════════════════════════════════════════════╗")
-    print("║  SuperLocalMemory V3 — The Unified Brain               ║")
+    print("║  SuperLocalMemory V4 — The Unified Brain               ║")
     print("║  by Varun Pratap Bhardwaj / Qualixar                   ║")
     print("╚══════════════════════════════════════════════════════════╝")
     print()

--- a/src/superlocalmemory/mcp/server.py
+++ b/src/superlocalmemory/mcp/server.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
 # Licensed under AGPL-3.0-or-later - see LICENSE file
-# Part of SuperLocalMemory V3 | https://qualixar.com | https://varunpratap.com
+# Part of SuperLocalMemory V4 | https://qualixar.com | https://varunpratap.com
 
-"""SuperLocalMemory V3 — MCP Server.
+"""SuperLocalMemory V4 — MCP Server.
 
 Clean MCP server calling V3 MemoryEngine. Supports all MCP-compatible IDEs.
 
@@ -33,7 +33,7 @@ from superlocalmemory.mcp.http_transport import SLMFastMCP
 logger = logging.getLogger(__name__)
 
 # mcp 2.0.0: MCPServer takes version= directly (no private _mcp_server poke).
-server = SLMFastMCP("SuperLocalMemory V3", version=_slm_version)
+server = SLMFastMCP("SuperLocalMemory V4", version=_slm_version)
 
 # Lazy engine singleton -------------------------------------------------------
 
@@ -83,7 +83,7 @@ def reset_engine():
 # Antigravity, Windsurf) and a maximal SLM registration crowds out
 # other MCP servers the user may have installed.
 # Admin/diagnostics tools remain available via CLI (`slm <command>`).
-# Set SLM_MCP_ALL_TOOLS=1 to enable all 84 tools (power users).
+# Set SLM_MCP_ALL_TOOLS=1 to enable all 87 tools (power users).
 
 import os as _os_reg
 

--- a/src/superlocalmemory/mcp/tools_core.py
+++ b/src/superlocalmemory/mcp/tools_core.py
@@ -939,7 +939,7 @@ def register_core_tools(server, get_engine: Callable) -> None:
         """Get system attribution: author, version, license, and provenance metadata."""
         return {
             "success": True,
-            "product": "SuperLocalMemory V3",
+            "product": "SuperLocalMemory V4",
             "author": "Varun Pratap Bhardwaj",
             "organization": "Qualixar",
             "license": "AGPL-3.0-or-later",

--- a/src/superlocalmemory/server/api.py
+++ b/src/superlocalmemory/server/api.py
@@ -109,8 +109,8 @@ async def lifespan(application: FastAPI):
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     application = FastAPI(
-        title="SuperLocalMemory V3 API",
-        description="V3 Memory Engine REST API",
+        title="SuperLocalMemory V4 API",
+        description="V4 Memory Engine REST API",
         version=SLM_VERSION,
         lifespan=lifespan,
     )
@@ -240,9 +240,9 @@ def create_app() -> FastAPI:
         index_path = UI_DIR / "index.html"
         if not index_path.exists():
             return (
-                "<html><head><title>SuperLocalMemory V3</title></head>"
+                "<html><head><title>SuperLocalMemory V4</title></head>"
                 "<body style='font-family:Arial;padding:40px'>"
-                "<h1>SuperLocalMemory V3 API Server Running</h1>"
+                "<h1>SuperLocalMemory V4 API Server Running</h1>"
                 "<p><a href='/docs'>API Documentation</a></p>"
                 "</body></html>"
             )
@@ -272,7 +272,7 @@ def create_app() -> FastAPI:
 if __name__ == "__main__":
     app = create_app()
     print("=" * 60)
-    print("SuperLocalMemory V3 - API Server (standalone mode)")
+    print("SuperLocalMemory V4 - API Server (standalone mode)")
     print("=" * 60)
     print(f"Database: {DB_PATH}")
     print(f"UI Directory: {UI_DIR}")

--- a/src/superlocalmemory/server/ui.py
+++ b/src/superlocalmemory/server/ui.py
@@ -72,8 +72,8 @@ UI_DIR = Path(__file__).resolve().parent.parent / "ui"
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     application = FastAPI(
-        title="SuperLocalMemory V3 UI Server",
-        description="Memory Dashboard with V3 Engine, Trust, Learning, and Compliance",
+        title="SuperLocalMemory V4 UI Server",
+        description="Memory Dashboard with V4 Engine, Trust, Learning, and Compliance",
         version=SLM_VERSION,
         docs_url="/api/docs",
         redoc_url="/api/redoc",
@@ -224,9 +224,9 @@ def create_app() -> FastAPI:
         if not index_path.exists():
             return (
                 "<!DOCTYPE html><html><head>"
-                "<title>SuperLocalMemory V3</title></head>"
+                "<title>SuperLocalMemory V4</title></head>"
                 "<body style='font-family:Arial;padding:40px'>"
-                "<h1>SuperLocalMemory V3 UI Server Running</h1>"
+                "<h1>SuperLocalMemory V4 UI Server Running</h1>"
                 "<p>UI not found. Check ui/index.html</p>"
                 "<p><a href='/api/docs'>API Documentation</a></p>"
                 "</body></html>"
@@ -290,7 +290,7 @@ if __name__ == "__main__":
     import argparse
     import socket
 
-    parser = argparse.ArgumentParser(description="SuperLocalMemory V3 - Web Dashboard")
+    parser = argparse.ArgumentParser(description="SuperLocalMemory V4 - Web Dashboard")
     parser.add_argument("--port", type=int, default=8765, help="Port (default 8765)")
     parser.add_argument("--profile", type=str, default=None, help="Memory profile")
     args = parser.parse_args()
@@ -310,7 +310,7 @@ if __name__ == "__main__":
         print(f"\n  Port {args.port} in use -- using {ui_port} instead\n")
 
     print("=" * 70)
-    print("  SuperLocalMemory V3 - Web Dashboard")
+    print("  SuperLocalMemory V4 - Web Dashboard")
     print("  Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar")
     print("=" * 70)
     print(f"  Database:  {DB_PATH}")

--- a/src/superlocalmemory/server/unified_daemon.py
+++ b/src/superlocalmemory/server/unified_daemon.py
@@ -2812,7 +2812,7 @@ def create_app() -> FastAPI:
     from superlocalmemory.server.routes.helpers import SLM_VERSION
 
     application = FastAPI(
-        title="SuperLocalMemory V3 — Unified Daemon",
+        title="SuperLocalMemory V4 — Unified Daemon",
         description="Memory + Dashboard + Mesh — one process, one engine.",
         version=SLM_VERSION,
         lifespan=lifespan,
@@ -3519,9 +3519,9 @@ def _register_dashboard_routes(application: FastAPI) -> None:
         index_path = UI_DIR / "index.html"
         if not index_path.exists():
             return (
-                "<html><head><title>SuperLocalMemory V3</title></head>"
+                "<html><head><title>SuperLocalMemory V4</title></head>"
                 "<body style='font-family:Arial;padding:40px'>"
-                "<h1>SuperLocalMemory V3 — Unified Daemon</h1>"
+                "<h1>SuperLocalMemory V4 — Unified Daemon</h1>"
                 "<p><a href='/docs'>API Documentation</a></p>"
                 "</body></html>"
             )

--- a/tests/test_cli/test_release_help_surface.py
+++ b/tests/test_cli/test_release_help_surface.py
@@ -56,3 +56,56 @@ def test_every_advertised_root_command_has_activation_free_help(
     assert result.returncode == 0, result.stderr
     assert "usage: slm" in result.stdout.lower()
     assert not (tmp_path / "must-not-be-created").exists()
+
+
+def test_root_help_identifies_v4_without_changing_version(
+    tmp_path: Path,
+) -> None:
+    """The public banner must name V4 and retain the package version."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    env["SLM_HOME"] = str(tmp_path / "must-not-be-created")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from superlocalmemory.cli.main import main; import sys; "
+            "sys.argv=['slm', '--help']; main()",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SuperLocalMemory V4 (4.0.0)" in result.stdout
+    assert "SuperLocalMemory V3" not in result.stdout
+
+
+def test_dashboard_help_does_not_claim_fixed_tab_count(
+    tmp_path: Path,
+) -> None:
+    """Dashboard navigation is not a fixed CLI contract."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    env["SLM_HOME"] = str(tmp_path / "must-not-be-created")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from superlocalmemory.cli.main import main; import sys; "
+            "sys.argv=['slm', '--help']; main()",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "dashboard" in result.stdout.lower()
+    assert "Open web dashboard" in result.stdout
+    assert "17-tab" not in result.stdout

--- a/tests/test_cli_core.py
+++ b/tests/test_cli_core.py
@@ -28,7 +28,7 @@ def test_main_status(capsys):
     with patch("sys.argv", ["slm", "status"]):
         main()
     captured = capsys.readouterr()
-    assert "SuperLocalMemory V3" in captured.out
+    assert "SuperLocalMemory V4" in captured.out
 
 
 def test_main_mode_get(capsys):

--- a/tests/test_cli_json.py
+++ b/tests/test_cli_json.py
@@ -146,7 +146,7 @@ class TestBackwardCompatibility:
         with patch("sys.argv", ["slm", "status"]):
             main()
         captured = capsys.readouterr()
-        assert "SuperLocalMemory V3" in captured.out
+        assert "SuperLocalMemory V4" in captured.out
         # Must NOT be valid JSON (it's human-readable text)
         with pytest.raises(json.JSONDecodeError):
             json.loads(captured.out)

--- a/tests/test_mcp/test_mcp_exposure_contract.py
+++ b/tests/test_mcp/test_mcp_exposure_contract.py
@@ -215,3 +215,34 @@ async def test_core_registered_callables_work_in_each_product_mode(
     assert session["retrieval_mode"] == "hybrid_candidate_fusion"
     assert session["memory_count"] == 0
     assert session["session_id"].startswith("slm-")
+
+
+@pytest.mark.asyncio
+async def test_attribution_reports_current_product_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public attribution tool must agree with the V4 MCP server name."""
+    mod = _fresh_server(monkeypatch, "whole")
+    registered = {
+        tool.name: tool.fn for tool in mod.server._tool_manager.list_tools()
+    }
+
+    attribution = await registered["get_attribution"]()
+
+    assert attribution["product"] == "SuperLocalMemory V4"
+
+
+def test_imported_server_exposes_product_name_and_whole_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Imported MCP server keeps product identity and whole surface at 87."""
+    mod = _fresh_server(monkeypatch, "whole")
+    # Public SLMFastMCP/MCPServer attribute — do not assert private internals.
+    assert mod.server.name == "SuperLocalMemory V4"
+    strict = _StrictToolServer()
+    _register_every_tool(strict)
+    assert len(strict.tools) == 87
+    actual_names = [tool.name for tool in mod.server._tool_manager.list_tools()]
+    assert len(actual_names) == 87
+    assert len(actual_names) == len(set(actual_names))
+    assert set(actual_names) == set(strict.tools)

--- a/tests/test_server/test_v4_deployment_and_ui_truth.py
+++ b/tests/test_server/test_v4_deployment_and_ui_truth.py
@@ -71,6 +71,21 @@ def test_dashboard_does_not_claim_unconditional_locality_or_legal_compliance() -
     assert "EU AI Act compliant" not in settings
 
 
+def test_live_server_surfaces_identify_v4() -> None:
+    live_v3_labels = (
+        'title="SuperLocalMemory V3',
+        '<title>SuperLocalMemory V3',
+        '<h1>SuperLocalMemory V3',
+        'print("SuperLocalMemory V3',
+    )
+    for name in ("api.py", "ui.py", "unified_daemon.py"):
+        source = (ROOT / "src/superlocalmemory/server" / name).read_text(
+            encoding="utf-8"
+        )
+        assert "SuperLocalMemory V4" in source
+        assert not any(label in source for label in live_v3_labels)
+
+
 def test_operations_resolution_uses_shared_destructive_confirmation() -> None:
     source = (
         ROOT / "src/superlocalmemory/ui/js/od-ops-health.js"

--- a/wiki-content/CLI-Reference.md
+++ b/wiki-content/CLI-Reference.md
@@ -1,8 +1,8 @@
-# CLI Reference
+# CLI Reference — V4.0.0
 
 The installed CLI is the command source of truth. Use `slm --help` and
 `slm <command> --help`; commands that advertise `--json` provide structured
-output.
+output. This page describes **V4.0.0**; the installed `--help` wins if prose drifts.
 
 ## Setup & Status
 
@@ -16,6 +16,8 @@ output.
 | `slm provider set` | Configure LLM provider (Mode B/C) |
 | `slm health` | Show math layer health (Fisher-Rao, Sheaf, Langevin stats) |
 | `slm warmup` | Pre-download embedding model (~500MB, one-time) |
+| `slm doctor [--fix] [--quick] [--json]` | Pre-flight checks (deps, embedding worker, daemon) |
+| `slm restart` | Kill orphans, clean state, start fresh, verify health |
 
 ## Memory Operations
 
@@ -29,7 +31,7 @@ slm remember "Shared decision" --scope shared --shared-with team-a
 slm remember "Wait for enrichment" --sync --json
 ```
 
-Store a memory. The default daemon path commits raw evidence plus a queryable SQLite relational/FTS projection, then enriches the same durable operation in the background.
+Store a memory. The default daemon path commits raw evidence plus a queryable SQLite relational/FTS projection, then enriches the same durable operation in the background. V4 seals a hash-verifiable completion manifest (COMPLETE or explicitly DEGRADED).
 
 Options:
 - `--tags "tag1,tag2"` — Add tags
@@ -40,7 +42,7 @@ Options:
 
 JSON output includes `operation_id`, `materialization_state`, and fact IDs. If
 the daemon cannot start, raw evidence enters the legacy offline spool; replay
-submits it through M018 before marking that spool row done.
+submits it through M018 before marking that spool row done. Stuck ops surface via `slm ops list`.
 
 ### Recall
 
@@ -49,9 +51,9 @@ slm recall "JWT token configuration"
 slm recall "auth setup" --limit 5 --json
 ```
 
-Retrieve memories using the candidate producers healthy in the configured
-mode, followed by fusion, optional reranking, and graph-based score
-enhancement. Results follow [Score Contract v2](Retrieval-Score-Contract).
+Retrieve memories using the **five candidate producers** healthy in the configured
+mode (semantic, BM25 lexical, temporal, Hopfield associative, spreading activation), followed by RRF fusion, optional reranking, and graph-based score
+enhancement (entity graph is an enhancement, not a 6th producer). Results follow [Score Contract v2](Retrieval-Score-Contract).
 
 Options:
 - `--limit N` — Number of results (default: 20)
@@ -79,7 +81,7 @@ slm trace "database port" --json
 
 Same as recall, but shows per-channel score breakdown. Current candidate
 producers are dense semantic, BM25 lexical, temporal, Hopfield associative, and
-spreading activation. Entity-graph information can enhance a post-fusion score
+spreading activation (5 producers). Entity-graph information can enhance a post-fusion score
 but is not a separate candidate producer.
 
 Options:
@@ -121,7 +123,7 @@ slm update <fact_id> "corrected content"
 slm update <fact_id> "new text" --json
 ```
 
-Update the content of a specific memory. Use `slm list` to find fact IDs.
+Update the content of a specific memory. Use `slm list` to find fact IDs. V4 re-indexes the corrected fact everywhere (semantic + keyword).
 
 Options:
 - `--json` — Output structured JSON
@@ -132,9 +134,10 @@ Options:
 slm connect        # Auto-detect and configure all installed IDEs
 slm connect --list # Show which IDEs are configured
 slm mcp            # Start MCP server (stdio transport — used by IDEs)
+# HTTP transport also available: http://127.0.0.1:8765/mcp/
 ```
 
-The `slm mcp` command is what your IDE calls internally. You typically don't run it directly — your IDE's MCP config handles it:
+The `slm mcp` command is what your IDE calls internally for stdio. You typically don't run it directly — your IDE's MCP config handles it:
 
 ```json
 {
@@ -152,19 +155,64 @@ The `slm mcp` command is what your IDE calls internally. You typically don't run
 ```bash
 slm profile list              # List all profiles
 slm profile create <name>     # Create a new profile
-slm profile switch <name>     # Switch active profile
+slm profile switch <name>     # Switch active profile (RBAC member-gated)
 ```
 
 Personal facts are profile-isolated by default. Shared and global recall are
 opt-in and remain subject to the configured scope policy; do not use profiles
-as a substitute for operating-system or tenant isolation.
+as a substitute for operating-system or tenant isolation. See [[RBAC and Teams]] and [[GDPR Compliance]].
 
-## Migration
+## Migration (two distinct commands)
+
+### `slm migrate` — V2 → V3 data migration
 
 ```bash
-slm migrate                   # Upgrade V2 database to V3
-slm migrate --rollback        # Undo migration
+slm migrate                   # Upgrade V2 database to V3 (V2Migrator)
+slm migrate --rollback        # Undo migration while the created backup still exists
 ```
+
+For existing V2 (2.8.6 or earlier) installations. This is not a single atomic transaction: it spans file copies (`~/.claude-memory/memory.db` → `~/.superlocalmemory/memory-v2-backup.db` and `~/.superlocalmemory/memory.db`), SQLite commits that add V3 tables/columns and re-index for 5-producer retrieval, and a rename/symlink (`~/.claude-memory` → `~/.superlocalmemory`) — failures are reported, not silently rolled back. A backup is created (`~/.superlocalmemory/memory-v2-backup.db` and `~/.claude-memory-v2-original` when applicable); operators must verify the result (`slm status`, `slm health`, `slm status --json | jq '.data.fact_count'`, and recall checks) before relying on the new store. Rollback via `slm migrate --rollback` is only possible while the created backup still exists — verify (`ls ~/.superlocalmemory/memory-v2-backup.db` and check for `~/.claude-memory-v2-original`) before use; code has no automatic 30-day deletion or guaranteed window. Nothing is done if no V2 installation is detected.
+
+### `slm db migrate` — V4 additive schema maintenance
+
+```bash
+slm db migrate --status       # Inspect forward/deferred migrations
+slm db migrate                # Apply pending additive migrations (forward only)
+slm db migrate --dry-run      # Preview (no writes)
+```
+
+Wraps LLD-07 additive migrations — **forward apply only** with `status` and `dry-run` inspection. There is no `slm db migrate --rollback`; `src/superlocalmemory/cli/db_migrate.py` supports only `status`, `dry-run`, and forward `apply`. Refuses to run against a DB written by a newer build; a migration whose dependency did not complete is held back. V4.0.0 includes M038 (eager, applied at startup) and M039 (deferred, applied once engine-owned tables exist) — no manual `slm db migrate` is normally required. Schema downgrade is unsupported; to revert a V4 upgrade, restore a verified pre-upgrade backup of the complete data root (see backup guidance below — stop the daemon first and copy the data-root store set with WAL/SHM). This is **not** the V2→V3 migrator above.
+
+### `slm db scale` — parity-gated projections
+
+```bash
+slm db scale status                              # Show Scale Engine state
+slm db scale prepare                             # Stage a new projection
+slm db scale verify --stage-id <id>             # Verify parity with canonical SQLite
+slm db scale promote --stage-id <id>            # Promote verified projection
+slm db scale rollback --backup-id <id>          # Roll back to a prior projection
+slm db scale adopt                               # Adopt a detected pre-v3.7 projection
+```
+
+## Operations & remediation (V4)
+
+```bash
+slm ops list --profile <name> --json   # List failed/stuck/degraded ops (admin)
+slm ops resolve <operation_id> --action retry|force_reconcile|cancel
+slm ops status --json                  # Quick failure count + writer stall overview
+```
+
+MCP equivalents (`power`/`whole` profile): `list_failed_operations`, `resolve_operation` (see [MCP Tools](MCP-Tools)). Also visible in the dashboard Operations / Health panel.
+
+## Bounded loops (V4)
+
+```bash
+slm loop demo --iterations 10 --json   # Keyless convergence demo (deterministic stub)
+slm loop history --name <loop> --json  # List recorded runs for a loop
+slm loop show <run_id> --json          # Show every lap of one run
+```
+
+MCP: `slm_loop_run` / `slm_loop_history` / `slm_loop_show` (`code`/`full`/`power`/`whole`). See [Bounded Loops](Bounded-Loops).
 
 ## Dashboard
 
@@ -173,7 +221,22 @@ slm dashboard                 # Open web dashboard at http://localhost:8765
 slm dashboard --port 9000     # Use a custom port
 ```
 
-11-workspace dashboard: Dashboard, Brain, Knowledge Graph, Memories, Health, Operations, Entity Explorer, Skill Evolution, Mesh Peers, Settings, and Optimize.
+Local dashboard workspaces include Dashboard, Brain, Knowledge Graph, Memories, Health, Governance (Access & Users / Data Privacy / Audit / Lifecycle & Trust), Operations, Entity Explorer, Skill Evolution, Mesh Peers, MCP & Tools, Cloud Backup, Settings, and Optimize. Workspace/tab counts are illustrative — verify the installed build; do not treat a tab count as a contract.
+
+## Other notable commands
+
+```bash
+slm evidence export <dest> --profile default --json   # Checksummed JSONL bundle (GDPR Art. 15/20)
+slm evidence verify <bundle> --json
+slm evidence import <bundle> --profile default --replace --json
+slm diagnostics export <dest> --json                  # Bounded operational aggregates
+slm cache status|clear|invalidate|ttl|semantic --json
+slm compress status|mode|code|prose|ccr --json
+slm optimize status|on|off|savings --since 7 --json
+slm proxy --port 8765 --provider anthropic            # Optimization proxy
+```
+
+Run `slm --help` and `slm <command> --help` for the full surface — this page is an orientation map, not the complete parser.
 
 ## Examples
 
@@ -206,7 +269,7 @@ ranking relevance separate from stored-memory confidence:
 {
   "success": true,
   "command": "recall",
-  "version": "<installed-version>",
+  "version": "4.0.0",
   "data": {
     "results": [
       {
@@ -256,10 +319,10 @@ SuperLocalMemory exposes both MCP and CLI surfaces:
 
 | Need | Use | Example |
 |------|-----|---------|
-| IDE integration | MCP | Run `slm connect --list`, then configure a listed client |
+| IDE integration | MCP (87 whole / 42 full default) | Run `slm connect --list`, then configure a listed client |
 | Shell scripts | CLI + `--json` | `slm recall "auth" --json \| jq '.data.results'` |
 | CI/CD pipelines | CLI + `--json` | `slm remember "deployed v2.1" --json` |
-| Agent frameworks | CLI + `--json` | OpenClaw, Codex, Goose, nanobot |
+| Agent frameworks | CLI + `--json` + adapters | [[Framework Adapters]] — 9 adapters |
 | Human use | CLI | `slm recall "auth"` (readable output) |
 
 ## Common Command List
@@ -273,9 +336,10 @@ This is an orientation list, not the complete installed surface. Run `slm
 | 2 | `slm mode [a\|b\|c]` | Yes | Get or set operating mode |
 | 3 | `slm provider [set]` | | Get or set LLM provider |
 | 4 | `slm connect [--list]` | Yes | Configure IDE integrations |
-| 5 | `slm migrate [--rollback]` | | V2 to V3 migration |
+| 5 | `slm migrate [--rollback]` | | **V2→V3 data migration** — rollback only while backup still exists; verify before use (`slm db migrate` is different — see above) |
+| 5b | `slm db migrate [--status \| --dry-run]` | | Additive schema maintenance (V4, forward only; no rollback) |
 | 6 | `slm remember "..."` | Yes | Store a memory |
-| 7 | `slm recall "..." [--limit N]` | Yes | Search memories |
+| 7 | `slm recall "..." [--limit N]` | Yes | Search memories (5 producers) |
 | 8 | `slm list [-n N]` | Yes | List recent memories (shows IDs) |
 | 9 | `slm forget "..." [--yes]` | Yes | Delete matching memories |
 | 10 | `slm delete <id> [--yes]` | Yes | Delete specific memory by ID |
@@ -283,10 +347,12 @@ This is an orientation list, not the complete installed surface. Run `slm
 | 12 | `slm status` | Yes | System status |
 | 13 | `slm health` | Yes | Math layer health |
 | 14 | `slm trace "..."` | Yes | Recall with channel breakdown |
-| 15 | `slm mcp` | | Start MCP server (for IDE) |
+| 15 | `slm mcp` | | Start MCP server (stdio, used by IDE) |
 | 16 | `slm warmup` | | Pre-download embedding model |
 | 17 | `slm dashboard [--port N]` | | Launch web dashboard |
 | 18 | `slm profile list\|create\|switch` | Yes | Profile management |
+| 19 | `slm ops list\|resolve\|status` | Yes | **V4** operational remediation |
+| 20 | `slm loop demo\|history\|show` | Yes | **V4** bounded loops |
 
 ---
 *Part of [Qualixar](https://qualixar.com) | Created by [Varun Pratap Bhardwaj](https://varunpratap.com)*

--- a/wiki-content/FAQ.md
+++ b/wiki-content/FAQ.md
@@ -1,12 +1,12 @@
-# FAQ
+# FAQ — V4.0.0
 
-Frequently asked questions about SuperLocalMemory V4.
+Frequently asked questions about SuperLocalMemory V4.0.0.
 
 ## General
 
 ### What is SuperLocalMemory?
 
-SuperLocalMemory is a persistent memory system for AI assistants. It stores your decisions, bug fixes, project context, and preferences locally, then automatically provides them to your AI in future sessions. Your AI stops forgetting you.
+SuperLocalMemory is a persistent memory system for AI assistants. It stores your decisions, bug fixes, project context, and preferences locally, then automatically provides them to your AI in future sessions via 5-channel retrieval (semantic, BM25, temporal, Hopfield, spreading activation — plus graph enhancement). Your AI stops forgetting you.
 
 ### Is it really free?
 
@@ -16,20 +16,21 @@ Yes. SuperLocalMemory is open-source (GNU Affero General Public License v3.0 or 
 
 Core memory is SQLite-backed inside the configured SLM data root. That root also contains configuration, logs, queues, models, and derived state. Mode C sends configured query or enrichment content to its provider; optional connectors, backup, and downloads have their own network behavior in every mode.
 
-### Which IDEs are supported?
+### Which IDEs and platforms are supported?
 
-Run `slm connect --list` for the release's documented client names. MCP-compatible clients can also be configured manually, but a client is considered verified only when it passes the release integration matrix.
+Run `slm connect --list` for the release's documented client names. MCP-compatible clients can also be configured manually, but a client is considered verified only when it passes the release integration matrix. V4 platform boundary: **Apple Silicon macOS, 64-bit Windows, 64-bit Linux** — Intel Mac and 32-bit Windows are not supported (`cryptography==50.0.0`).
 
 ### Does it work offline?
 
-Mode A and Mode B work fully offline. Mode C requires internet for the cloud LLM.
+Mode A and Mode B work fully offline. Mode C requires internet for the cloud LLM. Optional connectors, backup, and model downloads require network in any mode when explicitly enabled.
 
 ## Installation
 
 ### What are the requirements?
 
-- **Python** 3.11+ (required for V3 engine)
+- **Python** 3.11 – 3.14 (required for V4 engine)
 - **Node.js** 18+ (if installing via npm)
+- **Platform:** Apple Silicon macOS, 64-bit Windows, or 64-bit Linux (Intel Mac / Win32 not supported)
 - Any supported IDE
 - For Mode B: Ollama with a pulled model
 - For Mode C: API key for your cloud LLM provider
@@ -49,36 +50,41 @@ python -m pip install superlocalmemory
 slm setup
 ```
 
+See [Installation](Installation) for platform notes and troubleshooting.
+
 ### How do I update?
 
 ```bash
 npm install -g superlocalmemory@latest
 # or, while the SLM virtual environment is active:
 python -m pip install --upgrade superlocalmemory
+# then:
+slm restart && slm doctor
 ```
 
 ### I am upgrading from V2. Will I lose my data?
 
-No. Run `slm migrate` after updating. All memories, profiles, and settings are preserved. A backup is created automatically. See [Migration from V2](Migration-from-V2) for details.
+No. Run `slm migrate` (V2→V3 data migration) after updating — or `slm db migrate` for additive schema maintenance; they are different commands (see [CLI Reference](CLI-Reference)). All memories, profiles, and settings are preserved. A backup is created automatically. See [Migration from V2](Migration-from-V2) for details.
 
 ## Usage
 
 ### How does auto-recall work?
 
-When you start a conversation in your IDE, SuperLocalMemory automatically retrieves relevant memories and injects them into your AI's context. You do not need to call "recall" explicitly — it happens in the background via the MCP server.
+When you start a conversation in your IDE, SuperLocalMemory automatically retrieves relevant memories and injects them into your AI's context via the MCP server (`slm mcp` or HTTP `http://127.0.0.1:8765/mcp/`). You do not need to call "recall" explicitly — it happens according to the client's configured instructions/hooks.
 
 ### How do I store a memory?
 
 ```bash
 slm remember "The deploy script needs AWS_REGION set to us-east-1"
+slm remember "Decision" --scope shared --shared-with team-a
 ```
 
 ### What do queryable, enriching, complete, and failed mean?
 
 - `queryable` means raw evidence and the SQLite relational/FTS projection are durable and recallable.
 - `enriching` means a lease-owning worker is running configured derivation stages.
-- `complete` means every declared derivation and configured projector succeeded.
-- `failed` retains the raw evidence, error, attempt count, and retry timing; it is not silent data loss.
+- `complete` means every declared derivation and configured projector succeeded (and a hash-verifiable manifest is sealed).
+- `failed` retains the raw evidence, error, attempt count, and retry timing; it is not silent data loss (see `slm ops list` / `list_failed_operations`).
 
 ### How do I search memories?
 
@@ -86,19 +92,24 @@ slm remember "The deploy script needs AWS_REGION set to us-east-1"
 slm recall "deploy configuration"
 ```
 
+Current recall uses five candidate producers (semantic, BM25, temporal, Hopfield, spreading activation) plus entity-graph score enhancement.
+
 ### How do I see which retrieval channels found what?
 
 ```bash
 slm trace "deploy configuration"
 ```
 
-This shows per-channel scores (Semantic, BM25, Temporal, Hopfield, Spreading Activation) for each result. Entity-graph data can enhance a post-fusion score but is not a separate recall channel.
+This shows per-channel scores (Semantic, BM25, Temporal, Hopfield, Spreading Activation) for each result. Entity-graph data can enhance a post-fusion score but is not a separate recall channel. The current implementation is **five producers**, not four — earlier docs that said four-channel are obsolete.
 
 ### How do I delete a memory?
 
 ```bash
 slm forget "search query"     # Delete matching memories (with confirmation)
+slm delete <fact_id> --yes    # Delete one fact by ID (use slm list to find IDs)
 ```
+
+Use `slm ops list` or `list_failed_operations` (MCP, `power`/`whole` profile) to inspect stuck operations.
 
 ## Modes
 
@@ -114,48 +125,62 @@ Yes: `slm mode a`, `slm mode b`, or `slm mode c`. Your memories are shared acros
 
 ### What are the accuracy differences?
 
-The V3 paper provides published LoCoMo evidence carried into V3.7 architecture:
+The V3 paper provides **published LoCoMo evidence carried into V4 (not a newly rerun V4 benchmark)** — `arXiv:2603.14588`:
 
 - **60.4%** Mode A Raw across 10 conversations / 1,276 questions with zero-LLM answer construction.
 - **74.8%** Mode A Retrieval across the same scope with local retrieval and GPT-4.1-mini answer synthesis.
 - **87.7%** Mode C on Conv-30 / 81 questions with cloud embeddings and GPT-4.1-mini answer generation and judge.
 
-The figures retain their original protocol scope; they are not a newly rerun 3.7 package benchmark. See the linked preprint for category results, ablations, and limitations.
+The figures retain their original protocol scope; they are not a newly rerun V4 package benchmark and are not comparable across vendors without matching protocol (conversation scope, question count, retrieval stack, answer model, judge, release artifact). See the linked preprint for category results, ablations, and limitations. The non-rerun nature is explicit in [README](https://github.com/qualixar/superlocalmemory/blob/main/README.md#published-locomo-evidence-v3-architecture-carried-into-v4) and `docs/benchmarks.md`.
+
+## V4 Reliability Contract
+
+### What is actually verified with 2,200/2,200?
+
+Only one stress figure is verified in V4.0.0: **2,200/2,200 trials (100%)** from `benchmark/run_all.py --trials 200` (11 experiments × 200). Source: `benchmark/results/SUMMARY.md` (4.0.0, Python 3.13.13, macOS-26.5.2-arm64, 2026-08-08) and `benchmark/README.md` honesty notes (exp1 `embedding_metadata`-only without sqlite-vec ANN, exp2 lightweight `_TrackingOwner`, exp7 `_generation` set directly, etc.). No universal latency, p99, or throughput claim is made — use the measured `exp_governed_latency` p50 or run the harness on your own machine.
 
 ## Privacy and Security
 
 ### Can anyone else see my memories?
 
-No. Your database is a local file on your machine. It is not synced, uploaded, or shared with anyone — including us.
+No. Your database is a local file on your machine. It is not synced, uploaded, or shared with anyone — including us — unless you explicitly enable Mesh peering, cloud backup, or a provider-backed mode.
 
 ### Does it guarantee regulatory compliance?
 
-No software package certifies the complete deployment. SLM supplies local storage, erasure, provenance, retention, access-policy, and audit controls; applicability and sufficiency depend on the operator, use case, configuration, providers, and surrounding systems.
+No software package certifies the complete deployment. SLM supplies local storage, memory erasure (`slm forget`/`slm delete`) and dashboard profile erasure, provenance, retention, access-policy (RBAC — see [RBAC and Teams](RBAC-Teams)), and hash-chained audit controls (see [GDPR Compliance](GDPR-Compliance) and [Compliance](Compliance)); applicability and sufficiency depend on the operator, use case, configuration, providers, and surrounding systems.
 
 ### Can I export my data?
 
-The database is a standard SQLite file at `~/.superlocalmemory/memory.db`. You can copy it, back it up, or query it directly.
+The database is a standard SQLite file at `~/.superlocalmemory/memory.db`. Use `slm evidence export` for a checksummed JSONL bundle (see `slm evidence --help` and [GDPR Compliance](GDPR-Compliance)), or copy the data root. Configuration, logs, queues, models, derived indexes, and optional backend state also live in the data root.
 
 ### Can I delete all my data?
 
-`slm forget "query"` deletes matching memories. To delete everything, remove the database: `rm ~/.superlocalmemory/memory.db`.
+`slm forget "query"` deletes matching memories, and `slm delete <fact_id>` deletes an exact fact. V4 does not expose a `slm profile delete` CLI command; non-default profiles can be erased through **Dashboard → Governance → Data Privacy → Erase** with typed confirmation. To delete the complete installation, follow the documented erasure/uninstall procedure — do not assume removing only `memory.db` covers configuration, logs, queues, models, derived indexes, and optional backend state.
 
 ## Troubleshooting
 
 ### My AI does not seem to remember anything.
 
-1. Check that SuperLocalMemory is running: `slm status`
-2. Check that you have stored memories: `slm recall "test"`
-3. Verify your IDE connection: restart the IDE after configuring MCP
+1. Check that SuperLocalMemory is running: `slm status` / `slm health`
+2. Check that you have stored memories: `slm recall "test" --json`
+3. Verify your IDE connection: restart the IDE after configuring MCP (`slm connect --list`)
 4. Check the active profile: `slm profile list`
+5. Inspect stuck ops: `slm ops list` or dashboard Operations
 
 ### Recall returns irrelevant results.
 
-Try more specific queries. Use `slm trace "query"` to see which channels contribute — this helps diagnose whether the issue is semantic, keyword, or entity matching.
+Try more specific queries. Use `slm trace "query"` to see which channels contribute — this helps diagnose whether the issue is semantic, keyword, temporal, associative, or entity matching.
 
 ### The setup wizard does not detect my IDE.
 
-Use manual configuration. See [IDE Setup](IDE-Setup) for per-IDE config paths.
+Use manual configuration. See [IDE Setup](IDE-Setup) for per-IDE config paths. Supported list via `slm connect --list`.
+
+### Where do I find Bounded Loops, Framework Adapters, GDPR/RBAC, Multi-Agent Memory?
+
+- Bounded Loops: [Bounded Loops](Bounded-Loops) + `slm loop --help` + MCP `slm_loop_*` (`code`/`full`/`power`/`whole`)
+- Framework Adapters: [Framework Adapters](Framework-Adapters) — 9 adapters under `ide/integrations/`
+- GDPR/RBAC: [GDPR Compliance](GDPR-Compliance), [RBAC and Teams](RBAC-Teams), [Compliance](Compliance)
+- Multi-Agent Memory: [Multi-Agent Memory](Multi-Agent-Memory) + `SLM_AGENT_ID`
 
 ### Where can I report bugs?
 

--- a/wiki-content/GDPR-Compliance.md
+++ b/wiki-content/GDPR-Compliance.md
@@ -11,7 +11,7 @@ use case, and operator responsibility. SLM is not a legal certification.
 | Control | Where | CLI / Dashboard |
 |---------|-------|-----------------|
 | Data export (Art. 15/20) | Full profile data export as checksummed JSONL | `slm evidence export` · Dashboard → Governance → Data Privacy → Export |
-| Erasure (Art. 17) | Profile deletion removes data from 30+ scoped tables | `slm profile delete <name>` · Dashboard → Governance → Data Privacy → Erase |
+| Erasure (Art. 17) | Typed-confirmation profile erasure removes scoped profile data (the `default` profile cannot be erased) | Dashboard → Governance → Data Privacy → Erase; CLI supports individual `slm forget` / `slm delete`, not `slm profile delete` |
 | Erasure audit log | Erasure is logged to the tamper-proof audit chain before any data is deleted | Dashboard → Governance → Audit |
 | Retention rules (Art. 5) | Time-based expiry policies per workspace | `slm config set retention.default_policy gdpr-30d` |
 | Audit trail (Art. 5(2)) | Hash-chained record of every store, recall, mutation, and erasure | `slm diagnostics export` · Dashboard → Governance → Audit |

--- a/wiki-content/Getting-Started.md
+++ b/wiki-content/Getting-Started.md
@@ -95,7 +95,7 @@ See [IDE Setup](IDE-Setup) for per-IDE instructions.
 slm dashboard    # Opens at http://localhost:8765
 ```
 
-11 workspaces: Dashboard, Brain, Knowledge Graph, Memories, Health, Operations, Entity Explorer, Skill Evolution, Mesh Peers, Settings, and Optimize. Runs locally — no data leaves your machine.
+Dashboard workspaces include Dashboard, Brain, Knowledge Graph, Memories, Health, Operations, Entity Explorer, Skill Evolution, Mesh Peers, Settings, and Optimize (workspace/tab counts are illustrative — verify the installed build; do not treat a count as a contract). Runs locally — no data leaves your machine.
 
 ## Next Steps
 

--- a/wiki-content/Home.md
+++ b/wiki-content/Home.md
@@ -1,7 +1,7 @@
 # SuperLocalMemory V4.0.0
 
-> **V4 — governed local-first agent memory control plane built on the V3.8 foundation:
-> local-first agent memory, retrieval, cache, compression, trusted-peer
+> **V4.0.0 — governed local-first agent memory control plane built on the V3.8 foundation:
+> local-first agent memory, 5-channel retrieval, cache, compression, trusted-peer
 > coordination, team workspaces, roles, and governance controls.**
 
 SuperLocalMemory turns conversations, observations, and connected-source
@@ -11,10 +11,13 @@ canonical local store. The product also includes an explicit Scale Engine for
 CozoDB graph and LanceDB vector projections, a cache/compression module, and
 **SLM-Mesh** coordination controls.
 
+> **V4.0.0 is the current release** (see [CHANGELOG](https://github.com/qualixar/superlocalmemory/blob/main/CHANGELOG.md) and `src/superlocalmemory/__version__.py`). Every Current page in this Wiki describes V4. Historical V3 research pages are labeled as historical and carried forward where still accurate.
 
-## What changed in V4
+## What changed in V4.0.0
 
 V4 keeps the multi-channel retrieval and local-first store from the V3 research line, and productizes governed writes, **SLM-Mesh** peer coordination, multi-scope profiles, cache/compress, Entity Explorer and skill evolution, Modes A/B/C, and GDPR-oriented retention/audit controls. Operating mode is not legal certification under the EU AI Act — deployment context decides legal duties.
+
+V4 hardens the full lifecycle of a memory operation — admission, canonical commit, projection to every store, migration, backup, and erasure — so each step is authorized and verifiable against its manifest and logs. Existing V4 memories and configuration are preserved; M038 (eager) and M039 (deferred) migrations are automatically applied at startup so no manual `slm db migrate` is normally required (see [CLI Reference](CLI-Reference) — forward only, no rollback). Schema downgrade is unsupported; to revert a V4 upgrade, restore a verified pre-upgrade backup of the complete data root (stop the daemon first and include WAL/SHM). V2→V3 migration is a separate `slm migrate` command (see [Migration from V2](Migration-from-V2)).
 
 ## The product in one view
 
@@ -27,6 +30,7 @@ CLI · MCP HTTP/stdio · hooks · dashboard · IDEs · adapters
                               │
                               ▼
  semantic · BM25 · temporal · Hopfield · spreading activation
+   (5 candidate producers + entity-graph score enhancement)
                               │
                               ▼
  safe bounded context with policy, provenance and trace evidence
@@ -46,14 +50,37 @@ optional enrichers and retrieval channels are dependency- and mode-aware.
 |---|---|---|
 | Memory | Facts, scenes, temporal events, entities, profiles/scopes, memory lifecycle | Recalled content is untrusted evidence, never a new instruction. |
 | Ingestion | Replay-safe operation receipts; extraction, entity, graph, temporal, provenance and embedding derivations | Use `--sync` when a caller needs all declared stages, not only the immediate queryable receipt. |
-| Recall | Semantic, BM25, temporal, Hopfield and spreading-activation candidates; fusion, optional rerank and graph score enhancement | Runtime health determines the channels that participate. |
+| Recall | 5 candidate producers (semantic, BM25, temporal, Hopfield, spreading activation); RRF fusion, optional rerank and graph score enhancement | Runtime health determines the channels that participate; entity graph is a post-fusion enhancement, not a 6th candidate. |
 | Brain | Behavioral patterns, feedback/outcomes, reward signals, consolidation, soft prompts and guarded skill evolution | Learning is not a guarantee that an outcome was correct or beneficial. |
 | Graph | Canonical entities, aliases, profiles, edges, scenes, timelines and an Entity Explorer | Graph evidence is inspectable and provenance-bearing. |
-| Scale Engine | CozoDB graph + LanceDB vectors with prepare → verify → promote → rollback | SQLite remains canonical; promotion is explicit and parity-gated. |
+| Scale Engine | CozoDB graph + LanceDB vectors with `prepare → verify → promote → rollback` and `adopt` | SQLite remains canonical; promotion is explicit and parity-gated. |
 | Optimize | Exact cache, tag invalidation, safe compression, opt-in lossy prose compression and CCR originals | Only the proxy can intercept a primary provider turn. |
 | **SLM-Mesh** | Authenticated peer messages, locks, inbox/outbox, queues and optional discovery | Mesh coordinates peers; it is not a replicated distributed-memory database. |
 | Governance | Provenance, audit, retention, policy, export/erasure, health and diagnostics | Deployment configuration determines compliance posture. |
 | Integrations | CLI, Python SDK, MCP, Claude plugin, Codex add-on, documented IDE configs, Gmail/Calendar/transcript adapters, nine framework adapters (LangGraph, Semantic Kernel, Microsoft Agent Framework, LangChain, LlamaIndex, CrewAI, AutoGen, Google ADK, OpenAI Agents) | Connectors and hooks are opt-in and have their own data paths. |
+
+## V4 Reliability Contract — Verified 2,200/2,200 (Scoped)
+
+V4 states every reliability guarantee as a falsifiable invariant with an adversarial test, negative controls, and a shipped harness that regenerates the evidence. The only verified stress figure in V4 is the following; no other durability, latency, or throughput guarantee is claimed as a measured release envelope.
+
+> **Verified source:** `benchmark/results/SUMMARY.md` (package **4.0.0**, Python **3.13.13**, `macOS-26.5.2-arm64-arm-64bit-Mach-O`, generated `2026-08-08T08:38:21Z`) and `benchmark/README.md`. Reproduce with `python benchmark/run_all.py --trials 200 --output-dir results/` — 11 experiments × 200 trials = **2,200/2,200 (100.0%)** trials upheld their guarantee. Individual trial JSON under `benchmark/results/`.
+
+| Experiment | Guarantee | Metric |
+|---|---|---|
+| exp1_erasure_completeness | Real Bm25Owner + TemporalOwner + VectorOwner (embedding_metadata path; no sqlite-vec ANN in this env) erase all projection rows; tombstones + receipt persisted; keep-tenant hash unchanged | complete-erasure rate |
+| exp2_transaction_atomicity | Committed → COMPLETE; faulted → DEGRADED with `compensate()` removing successful projection (ledger states verified) | manifest-correct rate |
+| exp2b_real_owner_manifest | Happy path → COMPLETE with all three tables present; Bm25 fault → DEGRADED with zero residue and `compensate('temporal')` verified | manifest-correct rate |
+| exp3_migration_downgrade | Newer-stamped DB refused on deferred pass with zero mutation | refuse-and-preserve rate |
+| exp4_backup_restore_atomicity | Partial-restore failure rolls live data back to pre-restore bytes | rollback+clean rate |
+| exp5_multitenant_isolation | Personal rows never leak across tenants (positive control: requester still sees own data) | zero-leak rate |
+| exp6a/b/c | Superseded demotion, Ebbinghaus decay monotonicity, time-window inference | correct-demotion / monotonic-decay / correct-window |
+| exp7_generation_fence | Stale-epoch ADMISSION rejected; fresh-epoch admitted | fence-correct rate |
+| exp8_policy_registry | RBAC allow/deny with exact reason strings and unauthenticated→authentication_required | policy-correct rate |
+| exp_governed_latency | Governed write envelope p50 reported alongside bypass (distinct shape) | latency_ms |
+
+Explicit non-coverage (see `benchmark/README.md` honesty notes): fault-injection reliability and SLM's own temporal machinery — not an external agent-task benchmark; exp1 VectorOwner scope is `embedding_metadata` SQL only (ANN/`vector_row_map` excluded without sqlite-vec); exp2 uses a lightweight but complete `_TrackingOwner` (service/ledger/reconciler paths only); exp7 sets `runtime._generation` directly rather than exercising the full `rebind_engine` path; exp6b measures the shipped `EbbinghausCurve` function mathematically, not an end-to-end forgetting outcome.
+
+> **What this is not:** Published LoCoMo scores below are historical V3 architecture evidence (`arXiv:2603.14588`) carried into V4 for continuity. They are **not** a newly rerun V4 package benchmark and are not comparable across vendors without matching protocol (conversation scope, question count, retrieval stack, answer model, judge, and release artifact).
 
 ## Operating modes
 
@@ -74,7 +101,7 @@ ingestion, O(1) entity associations, responsive dashboard navigation, truthful
 Brain telemetry, company-mode authorization across learning controls, and
 repair of incomplete additive schemas such as Skill Evolution's cost ledger.
 
-## What V3.8.0 added
+## What V3.8.0 added (carried into V4)
 
 **Teams and enterprise memory**
 
@@ -84,10 +111,10 @@ repair of incomplete additive schemas such as Skill Evolution's cost ledger.
 - **Retention rules** — `indefinite`, `gdpr-30d`, `hipaa-7y`, `custom` policies per workspace
 - **PII redaction** — configurable automatic redaction before memory content crosses trust boundaries
 
-Personal installs are unchanged — no login required by default. See [[RBAC and Teams]] and [[GDPR Compliance]].
+Personal installs are unchanged — no login required by default. See [[RBAC and Teams]] and [[GDPR Compliance]] — and [[Compliance]] for the wider deployment view.
 
 **Bounded loops** — gate-verified iteration with a durable SLM-backed ledger. Three surfaces:
-`slm loop` CLI, `/slm-loop` plugin command, and MCP tools `slm_loop_run` /
+`slm loop` CLI (`demo` / `history` / `show`), the `/slm-loop` plugin command, and MCP tools `slm_loop_run` /
 `slm_loop_history` / `slm_loop_show`. The gate is an independent recall query;
 the agent's claim of completion is never used. See [[Bounded Loops]].
 
@@ -96,21 +123,14 @@ Framework, LangChain, LlamaIndex, CrewAI, AutoGen, Google ADK, and OpenAI
 Agents. Each implements its framework's native memory interface and writes
 through the SLM V4 ingestion contract. See [[Framework Adapters]].
 
-**MCP profile update** — profiles now include bounded-loop tools. Counts:
-core 14 / code 24 / full 42 / power 54 / whole 84. See [[MCP Tools]].
+**Multi-Agent Memory** — per-agent attribution via `SLM_AGENT_ID`, per-agent pane in the dashboard, and Mesh/lock coordination. See [[Multi-Agent Memory]].
+
+**MCP profile update** — profiles now include bounded-loop tools. V4 counts:
+`core` 14 / `code` 24 / `full` 42 / `power` 54 / `mesh` 8 / **`whole` 87** (all registered). See [[MCP Tools]].
 
 ## Dashboard workspaces
 
-V3.8.0 reorganized the dashboard navigation. The former "Operations" section is
-now **Governance**, with sub-tabs for Access & Users, Data Privacy, and Audit.
-A new **Integrations** group adds the **MCP & Tools** pane for profile management.
-
-The local dashboard includes Dashboard, Brain, Knowledge Graph, Memories,
-Health, Governance (Access & Users / Data Privacy / Audit / Lifecycle & Trust),
-Entity Explorer, Skill Evolution, Mesh Peers, MCP & Tools, Cloud Backup,
-Settings, and Optimize workspaces. Use it with `slm health`, `slm doctor`, and
-`slm trace` for operational verification rather than treating a visual status as
-a guarantee.
+The local dashboard (`slm dashboard`, default `http://localhost:8765`) exposes Dashboard, Brain, Knowledge Graph, Memories, Health, Governance (Access & Users / Data Privacy / Audit / Lifecycle & Trust), Entity Explorer, Skill Evolution, Mesh Peers, MCP & Tools, Cloud Backup, Settings, and Optimize workspaces. Workspace and tab counts are illustrative — verify the installed dashboard. Use `slm health`, `slm doctor`, and `slm trace` for operational verification rather than treating a visual status or tab count as a contract.
 
 ## Quick Start
 
@@ -129,4 +149,6 @@ python -m pip install superlocalmemory
 slm setup
 ```
 
-Then configure the client you intend to use and verify it with `slm doctor`.
+Then configure the client you intend to use and verify it with `slm doctor`. See [[Installation]], [[Getting Started]], and [[Quick Start Tutorial]].
+
+> **Platform boundary (V4):** **Apple Silicon macOS, 64-bit Windows, 64-bit Linux.** Intel Mac and 32-bit Windows are not supported — packaging metadata (`package.json` `os: [darwin, linux, win32]`) does not hard-block architectures; install will fail where `cryptography==50.0.0` wheels are absent (see `pyproject.toml`).

--- a/wiki-content/Installation.md
+++ b/wiki-content/Installation.md
@@ -1,18 +1,22 @@
-# Installation
+# Installation — V4.0.0
 
 SuperLocalMemory V4 has two primary paths: an npm global CLI with a
 package-owned Python environment, and a Python CLI + SDK inside an activated
 virtual environment. Repository-clone installers share the same release
 identity but have different ownership and verification contracts.
 
+> **Current release:** **V4.0.0** (`2026-08-01`, see [CHANGELOG](https://github.com/qualixar/superlocalmemory/blob/main/CHANGELOG.md)). All commands below describe the installed V4.0.0 artifact.
+
 ## Prerequisites
 
 | Requirement | Version | Check |
 |:-----------|:--------|:------|
-| **Python** | 3.11+ | `python3 --version` |
+| **Python** | 3.11 – 3.14 | `python3 --version` |
 | **Node.js** (for npm install) | 18+ | `node --version` |
 
-Python 3.11+ is required for the V3 engine. Node.js is only needed if you install via npm.
+Python 3.11+ is required for the V4 engine (built on the V3.8 control plane). Node.js is only needed if you install via npm.
+
+> **Platform boundary (V4):** **Apple Silicon macOS, 64-bit Windows, 64-bit Linux.** Intel Mac and 32-bit Windows are **not supported** by the pinned `cryptography==50.0.0` runtime — the package has no wheel for those architectures. `package.json` `os: [darwin, linux, win32]` is the npm publish descriptor and does not hard-block architectures; install will fail where `cryptography==50.0.0` wheels are absent (see `pyproject.toml` `cryptography==50.0.0`). The Python native dependency enforces the narrower boundary above.
 
 ---
 
@@ -89,7 +93,7 @@ slm status
 
 Dependency and model footprints vary by Python platform, resolver, selected
 backend, and configured embedding model. The values below are orientation from
-the historical default stack, not a V3.7 release envelope:
+the historical default stack, not a V4 release envelope:
 
 | Component | Size | When |
 |:----------|:-----|:-----|
@@ -113,7 +117,7 @@ declared full topology.
 
 ## Platform Notes
 
-### macOS (Apple Silicon + Intel)
+### Apple Silicon macOS (supported)
 
 ```bash
 npm install -g superlocalmemory
@@ -123,7 +127,9 @@ slm setup
 Use an existing supported Python 3.11–3.14 runtime. The npm installer does not
 bootstrap Homebrew, uv, pipx, or Python.
 
-### Linux (Ubuntu/Debian/Fedora)
+> Intel Mac is **not supported** in V4 (pinned `cryptography==50.0.0` has no Intel macOS wheel).
+
+### 64-bit Linux (Ubuntu/Debian/Fedora — supported)
 
 ```bash
 npm install -g superlocalmemory
@@ -132,15 +138,18 @@ slm setup
 
 Ensure Python 3.11+ is installed: `sudo apt install python3.11` (Ubuntu) or `sudo dnf install python3.11` (Fedora).
 
-### Windows
+### 64-bit Windows (supported)
 
 ```bash
 npm install -g superlocalmemory
 slm setup
 ```
 
-Requires an installed supported Python runtime. Hosted Windows artifact proof
-must pass for the frozen V3.7 release before the channel is marked verified.
+Requires an installed supported Python runtime (3.11–3.14, 64-bit).
+
+> 32-bit Windows (Win32) is **not supported** in V4.
+
+Hosted Windows artifact proof must pass for the frozen release before the channel is marked verified (see `benchmark/` — evidence is currently macOS-only; do not claim cross-platform verification beyond the installed runtime's `slm doctor`).
 
 ---
 
@@ -166,22 +175,35 @@ slm connect        # Configure all detected IDEs
 slm connect --list # See which IDEs are configured
 ```
 
-See [IDE Setup](IDE-Setup) for per-IDE instructions.
+See [IDE Setup](IDE-Setup) for per-IDE instructions. MCP tool counts in V4: `core` 14 / `code` 24 / `full` 42 / `power` 54 / `mesh` 8 / **`whole` 87** (see [MCP Tools](MCP-Tools)).
 
 ---
 
 ## Upgrading from V2
 
-If you have V2 (2.8.6 or earlier) installed:
+If you have V2 (2.8.6 or earlier) installed — **V2→V3 migration** (spans file copies, commits, and rename/symlink — not a single global transaction; verify after):
 
 ```bash
-npm install -g superlocalmemory    # Installs V3 alongside V2
-slm migrate                        # Migrates V2 data to V3 schema
+npm install -g superlocalmemory    # Installs V4 alongside V2
+slm migrate                        # V2→V3 data migration (V2Migrator)
+# Rollback only while the created backup still exists — verify before use:
+ls -lh ~/.superlocalmemory/memory-v2-backup.db; ls -ld ~/.claude-memory-v2-original
+slm migrate --rollback             # Valid only while migration backup still exists (no automatic 30-day deletion)
 ```
 
-V3 is a complete architectural reinvention — new mathematical engine, new retrieval pipeline, new storage schema. Your existing data is preserved. A backup is created automatically before migration.
+V3 is a complete architectural reinvention — new mathematical engine, new retrieval pipeline (5 candidate producers + graph enhancement), new storage schema. A backup is created (`~/.superlocalmemory/memory-v2-backup.db` / `~/.claude-memory-v2-original`); operators must verify (`slm status`, `slm health`, `slm status --json | jq '.data.fact_count'`) before decommissioning the prior state. This is not a zero-data-loss global transaction guarantee.
 
-See [Migration from V2](Migration-from-V2) for the full guide.
+**Not to be confused with `slm db migrate`** — the V4 additive schema maintenance command (forward only — see below and [CLI Reference](CLI-Reference)):
+
+```bash
+slm db migrate --status            # Inspect forward/deferred migrations
+slm db migrate --dry-run           # Preview (no writes)
+slm db migrate                     # Apply pending additive migrations (forward only; no rollback)
+# V4.0.0 M038 (eager) + M039 (deferred) are auto-applied at startup; no manual command normally required.
+# Schema downgrade is unsupported; restore a verified pre-upgrade backup of the complete data root (stop daemon, include WAL/SHM).
+```
+
+See [Migration from V2](Migration-from-V2) for the full V2→V3 guide.
 
 ---
 
@@ -195,6 +217,9 @@ See [Migration from V2](Migration-from-V2) for the full guide.
 - Ensure Python 3.11+ is the default: `python3 --version`
 - Activate the environment used for SLM, then reinstall with
   `python -m pip install --force-reinstall superlocalmemory`.
+
+### `cryptography` install fails on Intel Mac or Win32
+- Expected: V4's pinned `cryptography==50.0.0` has no wheel for those architectures — packaging metadata does not hard-block them, but install will fail where `cryptography==50.0.0` wheels are absent. Use Apple Silicon macOS, 64-bit Windows, or 64-bit Linux.
 
 ### Embedding model fails to download
 - Check internet connection
@@ -211,7 +236,8 @@ See [Migration from V2](Migration-from-V2) for the full guide.
 
 - [Quick Start Tutorial](Quick-Start-Tutorial) — Your first memory in 2 minutes
 - [Modes Explained](Modes-Explained) — Choose between A (zero-cloud), B (local Ollama), C (full power)
-- [CLI Reference](CLI-Reference) — Current command guidance and installed-help contract
+- [CLI Reference](CLI-Reference) — Current command guidance and installed-help contract (`slm --help` is the source of truth)
+- [MCP Tools](MCP-Tools) — V4 profile counts and the whole 87 distinction
 
 ---
 *Part of [Qualixar](https://qualixar.com) | Created by [Varun Pratap Bhardwaj](https://varunpratap.com)*

--- a/wiki-content/MCP-Tools.md
+++ b/wiki-content/MCP-Tools.md
@@ -1,16 +1,19 @@
-# MCP Tools
+# MCP Tools — V4.0.0 (87 whole)
 
 SuperLocalMemory exposes profile-selected tools and resources through the Model
-Context Protocol (MCP). The installed profile registry is the source of truth
+Context Protocol (MCP). The installed profile registry (`src/superlocalmemory/mcp/profiles.py` and `src/superlocalmemory/mcp/server.py`) is the source of truth
 for names and counts. An MCP-compatible client still decides when to call a
 tool.
+
+> **Current V4 profile counts (from `CHANGELOG.md 4.0.0` and the MCP exposure contract `tests/test_mcp/test_mcp_exposure_contract.py` / `tests/mcp/test_profile_selector.py`):**
+> `core` **14**, `code` **24**, `full` **42** (default everyday surface), `power` **54**, `whole` **87** (all registered), plus `mesh` **8**. See also `src/superlocalmemory/mcp/profiles.py`.
 
 > **Optimize tools:** `slm_compress`, `slm_retrieve`, `slm_cache_set`,
 > `slm_cache_get`, and `slm_optimize_stats` provide explicit compression and
 > routed-result caching. They do not intercept the primary conversation turn
 > without a proxy.
 
-> **V3.1 New:** 3 Active Memory tools (`session_init`, `observe`, `report_feedback`) and 1 resource (`slm://context`) for automatic learning and context injection.
+> **V3.1 New (carried into V4):** 3 Active Memory tools (`session_init`, `observe`, `report_feedback`) and 1 resource (`slm://context`) for automatic learning and context injection.
 
 ## Starting the MCP Server
 
@@ -18,7 +21,13 @@ tool.
 slm mcp    # Starts stdio transport — your IDE calls this automatically
 ```
 
-Your IDE config should look like:
+Preferred HTTP transport (V3.6.7+):
+
+```json
+{ "mcpServers": { "superlocalmemory": { "type": "http", "url": "http://127.0.0.1:8765/mcp/" } } }
+```
+
+Or stdio fallback:
 
 ```json
 {
@@ -36,7 +45,7 @@ Your IDE config should look like:
 | Tool | Parameters | Description |
 |------|-----------|-------------|
 | `remember` | `content`, `tags?`, `project?`, `importance?`, `session_id?`, `agent_id?`, `scope?`, `shared_with?`, `idempotency_key?` | Submit durable evidence and return an operation receipt |
-| `recall` | `query`, `limit?` | Retrieve relevant memories |
+| `recall` | `query`, `limit?` | Retrieve relevant memories (5 producers + graph enhancement) |
 | `search` | `query`, `limit?` | Search across all memories |
 | `forget` | `query` | Delete matching memories |
 | `fetch` | `id` | Get a specific memory by ID |
@@ -58,10 +67,10 @@ preserves the original source and idempotency identity.
 `recall`, `search`, `recall_trace`, and session context follow [Score Contract
 v2](Retrieval-Score-Contract). `relevance_score` is query relevance,
 `ranking_score` is diagnostic ranking utility, and `memory_confidence` belongs
-to the stored assertion. V3.7 declares `calibration_status: "uncalibrated"`
+to the stored assertion. V4 (like V3.8.0) declares `calibration_status: "uncalibrated"`
 and `answer_confidence: null`.
 
-## Active Memory Tools (V3.1)
+## Active Memory Tools (V3.1, carried into V4)
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
@@ -84,7 +93,7 @@ and `answer_confidence: null`.
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `recall_trace` | `query`, `limit?` | Recall with per-channel score breakdown |
+| `recall_trace` | `query`, `limit?` | Recall with per-channel score breakdown (5 producers) |
 | `get_lifecycle_status` | `limit?`, `status?` | Memory lifecycle health (active/warm/cold counts) |
 | `consistency_check` | — | Run sheaf consistency verification |
 | `set_mode` | `mode` | Switch operating mode (a/b/c) |
@@ -104,7 +113,7 @@ MCP resources provide read-only data streams that IDEs can subscribe to.
 | Learning State | `slm://learning` | Current state of the adaptive learning system |
 | Engagement | `slm://engagement` | Usage statistics and interaction patterns |
 
-## Optimize Tools (v3.6.11)
+## Optimize Tools (v3.6.11, carried into V4)
 
 Proxy-free compression and routed-result caching. The tools are designed to
 return `ok:False` with the original content on handled optimization failures;
@@ -121,32 +130,34 @@ boundary.
 
 > **Hard constraint:** Surfaces B and C cache results you explicitly route through SLM — not the Claude conversation turn. Full-turn caching requires Surface A (proxy).
 
-## MCP Profiles (V3.8.0)
+## MCP Profiles (V4.0.0 — whole is 87)
 
 A profile is a named, fixed subset of tools exposed to the connecting client.
-Set the active profile via the `SLM_MCP_PROFILE` environment variable or the
-`switch_profile` tool. The `whole` profile exposes the raw server with all
-tools (set `SLM_MCP_ALL_TOOLS=1`).
+Set the active profile via the `SLM_MCP_PROFILE` environment variable (or `SLM_MCP_ALL_TOOLS`/`SLM_MCP_TOOLS` overrides — see `src/superlocalmemory/mcp/server.py` precedence: `ALL > TOOLS > PROFILE > default`). `whole` exposes the raw server with all registered tools; `switch_profile` tool switches the active workspace profile (separate concept).
 
 | Profile | Tool count | Included surfaces |
 |---|---|---|
-| `core` | **14** | Store, recall, search, sessions, optimize |
-| `code` | **24** | Core + code-graph tools + profile switching + bounded loops |
-| `full` | **42** | All everyday memory, optimize, brain, and mesh tools |
+| `core` | **14** | Store, recall, search, sessions, optimize (5 tools) |
+| `code` | **24** | Core + code-graph (4) + `switch_profile` + 3 bounded-loop tools |
+| `full` | **42** | All everyday memory, optimize, brain, and mesh tools (default everyday surface) |
 | `power` | **54** | Full + governance and behavioral analysis tools |
-| `whole` | **84** | All registered tools (raw server) |
+| `mesh` | **8** | SLM-Mesh coordination only |
+| `whole` | **87** | All registered tools (raw server) — verified by `tests/test_mcp/test_mcp_exposure_contract.py` `whole == 87` |
 
-Legacy count-suffixed aliases (`code24`, `full42`, `power54`, `whole84`, etc.)
-resolve to their canonical name for backward compatibility.
+> **Why 87 not 84:** Earlier docs (and the `whole84` compatibility alias in `src/superlocalmemory/mcp/profiles.py`) reflected a pre-V4 registration count. V4 adds `list_failed_operations` + `resolve_operation` (`src/superlocalmemory/mcp/tools_ops.py`, Wave-3 remediation) and `prestage_context` (`src/superlocalmemory/mcp/tools_context.py`) to the raw registration — verified by counting `@server.tool` decorators (87 unique names). The aliases `whole81`/`whole84` still resolve to `whole` for backward compatibility but the installed `whole` surface is **87**.
+
+Legacy count-suffixed aliases (`core14`, `code20`/`code21`/`code24`, `full38`/`full39`/`full42`, `power50`/`power51`/`power54`, `mesh8`, `whole81`/`whole84`, and `whole87` where emitted) resolve to their canonical name for backward compatibility and emit a migration warning.
 
 The three bounded-loop tools (`slm_loop_run`, `slm_loop_history`,
 `slm_loop_show`) are included in `code`, `full`, `power`, and `whole`.
 See [Bounded Loops](Bounded-Loops) for the tool reference.
 
+**Retrieval note:** Current recall in V4 has **five candidate producers** — dense semantic, BM25 lexical, temporal, Hopfield associative, and spreading activation — followed by RRF fusion, optional reranking, and entity-graph score enhancement (the graph does not create a separate candidate). Some pre-V4 prose described “four-channel” retrieval; the current implementation is five producers (see [Retrieval Score Contract](Retrieval-Score-Contract) and `src/superlocalmemory/retrieval/`).
+
 Switch profiles without restarting the daemon:
 
 ```bash
-slm profile switch code    # CLI
+slm profile switch code    # CLI — switches active workspace profile
 ```
 
 Or via MCP tool:
@@ -155,22 +166,20 @@ Or via MCP tool:
 await switch_profile(name="full")
 ```
 
-The active profile is visible in the dashboard under **MCP & Tools**.
+The active MCP profile (`SLM_MCP_PROFILE`) and the active workspace profile (`slm profile ...`) are distinct controls. The dashboard **MCP & Tools** pane shows the active MCP profile.
 
 ## How MCP Integration Works
 
-1. Your IDE connects to the SuperLocalMemory MCP server via `slm mcp`
+1. Your IDE connects to the SuperLocalMemory MCP server via `slm mcp` (stdio) or HTTP `http://127.0.0.1:8765/mcp/`
 2. When you chat with your AI, the IDE calls `recall` with relevant context
-3. SuperLocalMemory runs the healthy subset of dense semantic, BM25 lexical,
-   temporal, Hopfield associative, and spreading-activation candidate
-   producers, then applies fusion and optional score enhancements
+3. SuperLocalMemory runs the healthy subset of its 5 candidate producers, then applies fusion and optional score enhancements
 4. The IDE injects those memories into the AI's context
 5. Your AI responds with knowledge of your past work
 
 Whether this happens automatically depends on the client and its configured
 instructions or hooks. SLM does not control an IDE's tool-selection policy.
 
-See [IDE Setup](IDE-Setup) for per-IDE configuration paths.
+See [IDE Setup](IDE-Setup) for per-IDE configuration paths and [Framework Adapters](Framework-Adapters) for framework-native memory.
 
 ---
 *Part of [Qualixar](https://qualixar.com) | Created by [Varun Pratap Bhardwaj](https://varunpratap.com)*

--- a/wiki-content/Migration-from-V2.md
+++ b/wiki-content/Migration-from-V2.md
@@ -1,37 +1,54 @@
-# Migration from V2
+# Migration from V2 — V4.0.0
 
-Upgrading from SuperLocalMemory V2 to V3 is a one-command process. No data is lost.
+Upgrading from SuperLocalMemory V2 (2.8.6 or earlier) to V4 is a one-command **data migration** that spans file copies, SQLite commits, and a rename/symlink — not a single global transaction. Additive schema work in V4 uses a different command (`slm db migrate`, forward only — see [CLI Reference](CLI-Reference)); do not conflate them.
 
-## What's New in V3
+> **V4.0.0 note:** V4.0.0 includes M038 (eager) and M039 (deferred) migrations that are **automatically applied at startup**; no manual `slm db migrate` is normally required for V4.0.0 itself (see [CHANGELOG](https://github.com/qualixar/superlocalmemory/blob/main/CHANGELOG.md#400---2026-08-01--verifiable-memory-transactions) and `src/superlocalmemory/storage/migration_runner.py`). Schema downgrade is unsupported — to revert a V4 upgrade, restore a verified pre-upgrade backup of the complete data root (stop the daemon first; see backup guidance below). The steps below apply only when upgrading from V2.
+
+## What's New Since V2
 
 - **Three operating modes** (A/B/C) — choose your privacy/accuracy trade-off
-- **Multi-producer retrieval** — five candidate producers (semantic, BM25, temporal, spreading-activation, Hopfield) fused via RRF, with an entity-graph post-fusion score enhancement
-- **Mathematical foundations** — information-geometric similarity, consistency checking, self-organizing lifecycle
+- **Multi-producer retrieval** — **five** candidate producers (semantic, BM25, temporal, spreading-activation, Hopfield) fused via RRF, with an entity-graph post-fusion score enhancement (not a 6th candidate)
+- **Mathematical foundations** — information-geometric similarity, consistency checking, self-organizing lifecycle (historical V3 research, labeled as such — see [[V3 Architecture]] and [[V3 Mathematical Foundations]])
+- **Governed writes (V4)** — admission + policy, per-store obligations, hash-sealed manifest, reconciler (see [Home](Home) reliability contract)
+- **SLM-Mesh, multi-scope profiles, cache/compress, Entity Explorer, skill evolution, Modes A/B/C, GDPR/RBAC** (see [[Capabilities and Operations]])
+- **Bounded loops & framework adapters (V3.8.0→V4)** — see [[Bounded Loops]] and [[Framework Adapters]]
+- **Scale Engine** — parity-gated CozoDB/LanceDB projections (see `slm db scale`)
 - **Scene and bridge discovery** — connects related memories across conversations
-- **Cross-encoder reranking** (Mode C) — precision ordering of results
+- **Cross-encoder reranking (Mode C)** — precision ordering of results
 - **Enhanced entity resolution** — smarter deduplication and linking
 
 ## Before You Migrate
 
-1. **Back up your database** (recommended but not required — migration creates an automatic backup):
+1. **Back up your database** (recommended but not required — migration creates a backup at `~/.superlocalmemory/memory-v2-backup.db` and `~/.claude-memory-v2-original` when applicable). Do **not** copy a live SQLite file while the daemon is running. Stop the daemon first and back up the complete data root or documented store set, handling WAL/SHM sidecars:
 
 ```bash
-cp ~/.claude-memory/memory.db ~/.claude-memory/memory.db.backup
+slm serve stop   # stop the daemon so the DB and WAL/SHM are quiescent
+# then back up the complete data root (or the documented store set):
+cp -a ~/.superlocalmemory ~/.superlocalmemory.pre-migrate-backup
+# alternative: tar with WAL/SHM sidecars
+tar -czf ~/slm-pre-migrate.tgz -C ~ .superlocalmemory
+# verify the backup before proceeding:
+ls -lh ~/.superlocalmemory.pre-migrate-backup/memory.db*  # includes memory.db, memory.db-wal, memory.db-shm where present
 ```
 
-2. **Update to the latest version:**
+2. **Update to the latest V4:**
 
 ```bash
 npm install -g superlocalmemory@latest
+# or
+python -m pip install --upgrade superlocalmemory
+slm restart && slm doctor
 ```
 
-3. **Check migration readiness:**
+3. **Check migration readiness** (V2→V3 migrator only — `slm db migrate --status` is the V4 schema command instead):
 
 ```bash
-slm migrate --status
+slm migrate            # prints status if no V2 found, or proceeds with confirmation
 ```
 
-## Migration Steps
+> There is no `slm migrate --status` flag in the installed parser (`src/superlocalmemory/cli/main.py`); `slm migrate` without args already reports whether a V2 installation exists. Use `slm db migrate --status` to inspect V4 additive migrations.
+
+## Migration Steps (V2→V3)
 
 Run the migration command:
 
@@ -39,16 +56,16 @@ Run the migration command:
 slm migrate
 ```
 
-The migration will:
-1. Create a backup of your V2 database
+The migration will (not a single atomic transaction — failures are reported mid-migration, not silently rolled back):
+1. Create a backup of your V2 database at `~/.superlocalmemory/memory-v2-backup.db` (and `~/.claude-memory-v2-original` for the directory) — verify it exists before relying on rollback
 2. Add V3 tables (entity graph, scenes, temporal events, math state)
 3. Add V3 columns to existing tables
-4. Re-index memories for multi-producer retrieval
+4. Re-index memories for 5-producer retrieval
 5. Build the entity graph from existing memories
-6. Move the database to `~/.superlocalmemory/` (with symlink from `~/.claude-memory/`)
-7. Update IDE configurations
+6. Move the database to `~/.superlocalmemory/` (with symlink/junction from `~/.claude-memory/` — platform-dependent)
+7. Update IDE configurations where possible
 
-This takes 1-5 minutes depending on database size.
+This takes 1-5 minutes depending on database size. It creates a backup but does not guarantee zero data loss as a global transactional property — operators must verify (`slm status`, `slm health`, `slm status --json | jq '.data.fact_count'`, and recall checks) before decommissioning the prior backup.
 
 ## What Gets Preserved
 
@@ -64,13 +81,14 @@ Everything from V2 carries over:
 
 ## What Changes
 
-| Item | V2 | V3 |
+| Item | V2 | V4 (via V3) |
 |------|----|----|
 | Database location | `~/.claude-memory/` | `~/.superlocalmemory/` (symlink for compat) |
 | Default mode | Single mode | Mode A (zero cloud) |
-| Retrieval | Semantic + FTS5 | Five producers (semantic + BM25 + temporal + spreading-activation + Hopfield) -> RRF + entity-graph enhancement |
+| Retrieval | Semantic + FTS5 | **Five producers** (semantic + BM25 + temporal + spreading-activation + Hopfield) → RRF + entity-graph enhancement |
 | Lifecycle | Manual | Self-organizing (Langevin dynamics) |
-| Consistency | None | Automatic contradiction detection |
+| Consistency | None | Automatic contradiction detection (sheaf) |
+| Writes (V4) | — | Governed, manifest-sealed, reconciled |
 
 ## After Migration
 
@@ -79,19 +97,33 @@ Verify the migration succeeded:
 ```bash
 slm status
 slm health
+slm ops status --json
 ```
 
-Check your memory count matches what you had before.
+Check your memory count matches what you had before (`slm status --json | jq '.data.fact_count'`).
 
-## Rollback
-
-If anything goes wrong, rollback within 30 days:
+## V4 Additive Schema Maintenance (not V2 migration)
 
 ```bash
+slm db migrate --status    # Inspect pending forward/deferred migrations
+slm db migrate --dry-run   # Preview (no writes)
+slm db migrate             # Apply pending additive migrations (forward only)
+```
+
+V4's `slm db migrate` is **forward apply only** (`status` / `dry-run` / apply); there is no `slm db migrate --rollback` (`src/superlocalmemory/cli/db_migrate.py` and `src/superlocalmemory/storage/migration_runner.py`). It refuses to run against a DB written by a newer build and holds back migrations whose dependencies did not complete. M038 is applied eagerly at startup; M039 is deferred until engine-owned tables exist — no manual command is normally required. Schema downgrade is unsupported; restore a verified pre-upgrade backup of the complete data root (stop the daemon first and include WAL/SHM) instead.
+
+## Rollback (V2→V3 only)
+
+If anything goes wrong with the V2→V3 migration, rollback is only possible while the created backup still exists:
+
+```bash
+# verify the backup the migrator created still exists before rolling back:
+ls -lh ~/.superlocalmemory/memory-v2-backup.db
+ls -ld ~/.claude-memory-v2-original  # directory backup when applicable
 slm migrate --rollback
 ```
 
-This restores your V2 database from the automatic backup and reverts IDE configurations.
+This restores your V2 database from the backup (`~/.superlocalmemory/memory-v2-backup.db` or `~/.claude-memory-v2-original`) and reverts IDE configurations where possible. Code has no automatic 30-day deletion — rollback is only possible while you still have the backup; verify before use.
 
 ## FAQ
 
@@ -99,10 +131,10 @@ This restores your V2 database from the automatic backup and reverts IDE configu
 No. The migration updates IDE configs automatically. The `~/.claude-memory/` path is symlinked to `~/.superlocalmemory/`, so old paths still work.
 
 **Do I need to re-store my memories?**
-No. All existing memories are preserved and re-indexed for V3's multi-producer retrieval.
+No. All existing memories are preserved and re-indexed for V4's 5-producer retrieval.
 
 **Can I go back to V2?**
-Yes, use `slm migrate --rollback` within 30 days. After 30 days, the backup is automatically removed.
+Only while the migrator-created backup still exists (`~/.superlocalmemory/memory-v2-backup.db` / `~/.claude-memory-v2-original`): `slm migrate --rollback`. Verify the backup exists before use — code has no automatic deletion or guaranteed time window.
 
 **Does migration require an internet connection?**
 No. The migration is entirely local.

--- a/wiki-content/Multi-Agent-Memory.md
+++ b/wiki-content/Multi-Agent-Memory.md
@@ -106,7 +106,7 @@ the daemon. Tools active under each profile:
 | `code` | 24 |
 | `full` | 42 |
 | `power` | 54 |
-| `whole` | 84 |
+| `whole` | 87 |
 
 ## Choosing a coordination mechanism
 

--- a/wiki-content/Quick-Start-Tutorial.md
+++ b/wiki-content/Quick-Start-Tutorial.md
@@ -119,7 +119,7 @@ Works with: Claude Code, Cursor, VS Code Copilot, Windsurf, Continue, Cody, Chat
 slm dashboard
 ```
 
-Opens at http://localhost:8765. 11 workspaces: Dashboard, Brain, Knowledge Graph, Memories, Health, Operations, Entity Explorer, Skill Evolution, Mesh Peers, Settings, and Optimize.
+Opens at http://localhost:8765. Dashboard workspaces include Dashboard, Brain, Knowledge Graph, Memories, Health, Operations, Entity Explorer, Skill Evolution, Mesh Peers, Settings, and Optimize (workspace/tab counts are illustrative — verify the installed dashboard; do not treat a count as a contract).
 
 ---
 
@@ -141,13 +141,13 @@ V3 installs alongside V2. Your V2 data is untouched until you migrate.
 slm migrate
 ```
 
-This will:
+This will (not a global transaction — spans file copies, commits, and symlink/junction; verify after):
 - Show your V2 stats (memory count, DB size)
 - Ask for confirmation
-- Back up your V2 database automatically
+- Create a backup at `~/.superlocalmemory/memory-v2-backup.db` / `~/.claude-memory-v2-original` (verify it exists before relying on rollback)
 - Copy data to the V3 location (`~/.superlocalmemory/`)
 - Convert V2 memories to V3 atomic facts
-- Create a symlink so old tools still find the data
+- Create a symlink/junction so old tools still find the data (platform-dependent)
 
 ### 3. Setup V3
 
@@ -174,17 +174,19 @@ slm recall "something you stored in V2"   # Verify old memories are accessible
 | Lifecycle | Hardcoded thresholds | Self-organizing Langevin dynamics |
 | Modes | Single mode | A (zero-cloud), B (local LLM), C (cloud LLM) |
 | Privacy and compliance controls | Not addressed | Deployment-specific controls and assessment |
-| Dashboard | 5 tabs | 11 workspaces |
+| Dashboard |_tabs are illustrative — verify the installed build_ | _workspace counts are illustrative — verify the installed dashboard_ |
 | MCP Tools | 6 | Profile-selected V3 tool surfaces |
 | Tests | Historical V2 suite | V3 unit, contract, artifact, and integration suites |
 
 ### Rollback if needed
 
 ```bash
+# rollback only while the migrator-created backup still exists — verify before use:
+ls -lh ~/.superlocalmemory/memory-v2-backup.db; ls -ld ~/.claude-memory-v2-original
 slm migrate --rollback
 ```
 
-This restores your V2 installation. No data is lost.
+This restores your V2 installation from the backup while it still exists; verify the backup (`~/.superlocalmemory/memory-v2-backup.db` / `~/.claude-memory-v2-original`) before use — code has no automatic deletion or guaranteed window. It spans file copies, commits, and rename/symlink and reports failures; verify the restored state.
 
 ---
 

--- a/wiki-content/_Footer.md
+++ b/wiki-content/_Footer.md
@@ -1,5 +1,7 @@
 ---
 
-**SuperLocalMemory V4** — Local-first memory with explicit data-path controls.
+**SuperLocalMemory V4.0.0** — Local-first memory with explicit data-path controls. Current docs: [Home](Home) · [Installation](Installation) · [CLI](CLI-Reference) · [MCP whole 87 (full 42 default)](MCP-Tools) · [FAQ](FAQ)
 
-Part of [Qualixar](https://qualixar.com) | Created by [Varun Pratap Bhardwaj](https://varunpratap.com) | [GitHub](https://github.com/qualixar/superlocalmemory)
+Part of [Qualixar](https://qualixar.com) | Created by [Varun Pratap Bhardwaj](https://varunpratap.com) | [GitHub](https://github.com/qualixar/superlocalmemory) · [CHANGELOG](https://github.com/qualixar/superlocalmemory/blob/main/CHANGELOG.md)
+
+> **Platform boundary:** Apple Silicon macOS · 64-bit Windows · 64-bit Linux — Intel Mac and 32-bit Windows not supported (`cryptography==50.0.0`).

--- a/wiki-content/_Sidebar.md
+++ b/wiki-content/_Sidebar.md
@@ -12,21 +12,22 @@
 
 **Reference**
 * [CLI Commands](CLI-Reference)
-* [MCP Tools](MCP-Tools)
+* [MCP Tools](MCP-Tools) — 87 whole / 54 power / 42 full / 24 code / 14 core
 * [Retrieval Score Contract](Retrieval-Score-Contract)
 * [Auto-Memory](Auto-Memory)
 * [Active Memory (V3.1)](Active-Memory)
 
 **Integrations**
-* [Framework Adapters](Framework-Adapters)
+* [Framework Adapters](Framework-Adapters) — 9 adapters
 * [Bounded Loops](Bounded-Loops)
 * [Multi-Agent Memory](Multi-Agent-Memory)
 
 **Architecture**
-* [Architecture Overview](V3-Architecture)
+* [Architecture Overview](V3-Architecture) — historical V3, carried into V4
 * [Capabilities and Operations](Capabilities-and-Operations)
-* [Published Benchmarks](V3-Architecture#benchmarks)
-* [Mathematical Foundations](V3-Mathematical-Foundations)
+* [Published Benchmarks](V3-Architecture#benchmarks) — V3 LoCoMo, not a V4 rerun
+* [Mathematical Foundations](V3-Mathematical-Foundations) — historical V3
+* [V4 Reliability Contract](Home#v4-reliability-contract--verified-22002200-scoped) — 2,200/2,200, protocol `benchmark/run_all.py --trials 200`
 
 **Enterprise and Teams**
 * [RBAC and Teams](RBAC-Teams)


### PR DESCRIPTION
## Summary

- finalizes SuperLocalMemory V4 identity across CLI, MCP, API, dashboard, docs, integration guides, and Wiki source
- reconciles V4 MCP profile counts and five-producer retrieval terminology with the shipped runtime
- corrects migration, backup/restore, privacy, credential, platform, and compliance guidance to match implemented behavior
- adds regression coverage for V4 public identity and the 87-tool whole MCP surface

## Local release gates

- 389 focused release/docs/CLI/MCP/server/security/migration/backup tests passed
- MCP streamable-HTTP client E2E passed
- post-review correction gate: 95 tests passed
- public claim scanner: green
- diff check: clean
- independent Luna code/Python/security review: PASS

## Release sequence

This PR makes GitHub `main` the V4 source of truth. The GitHub Wiki and annotated `v4.0.0` release follow after merge. Paper/Zenodo, exact-main installation testing, PyPI, and npm remain intentionally subsequent gates.
