### PR TITLE
Release SuperLocalMemory v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to SuperLocalMemory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-08-09 — Dashboard and operations-status correctness
+
+### Fixed
+- The packaged dashboard identifies itself as SuperLocalMemory V4 and uses an
+  absolute packaged favicon path. Both unified and standalone dashboard servers
+  now provide the conventional `/favicon.ico` route by redirecting to the
+  packaged SVG icon.
+- The daemon's operations-status counters now receive their FastAPI application
+  explicitly, so persisted dead-letter, degraded-manifest, and exhausted-
+  obligation counts cannot be silently reported as zero.
+
 ## [4.0.0] - 2026-08-01 — Verifiable memory transactions
 
 Version 4.0 hardens the full lifecycle of a memory operation — admission,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ authors:
   - family-names: "Bhardwaj"
     given-names: "Varun Pratap"
     orcid: "https://orcid.org/0009-0002-8726-4289"
-version: "4.0.0"
-date-released: "2026-08-08"
+version: "4.0.1"
+date-released: "2026-08-09"
 license: AGPL-3.0-or-later
 url: "https://superlocalmemory.com"
 repository-code: "https://github.com/qualixar/superlocalmemory"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </picture>
 </p>
 
-<h1 align="center">SuperLocalMemory V4.0.0</h1>
+<h1 align="center">SuperLocalMemory V4.0.1</h1>
 
 <h2 align="center">Rent the LLM. Own the memory.</h2>
 
@@ -27,13 +27,14 @@ guarantee here is stated as a falsifiable invariant, tested under an adversarial
 negative control, and shipped with the harness that regenerates the evidence:
 <code>python benchmark/run_all.py --trials 200 --output-dir results/</code>. What each experiment
 does <em>not</em> exercise is stated too.</p>
-<p align="center"><code>v4.0.0</code> — one control plane: <strong>SLM-Mesh</strong> peer coordination · multi-scope memory (personal / shared / global) · profiles · Cache · Compress · 7-layer retrieval · code graph · Entity Explorer · skill evolution · Modes A/B/C · GDPR retention &amp; audit chain · bounded loops — across CLI, MCP, dashboard, the <strong>Claude plugin</strong>, the <strong>Codex add-on</strong>, and documented IDE integrations.<br/>
+<p align="center"><code>v4.0.1</code> — one control plane: <strong>SLM-Mesh</strong> peer coordination · multi-scope memory (personal / shared / global) · profiles · Cache · Compress · 7-layer retrieval · code graph · Entity Explorer · skill evolution · Modes A/B/C · GDPR retention &amp; audit chain · bounded loops — across CLI, MCP, dashboard, the <strong>Claude plugin</strong>, the <strong>Codex add-on</strong>, and documented IDE integrations.<br/>
 Proxy: <code>slm wrap claude</code> &nbsp;·&nbsp; MCP: add <code>slm_compress</code> to your config &nbsp;·&nbsp; Skill: zero-config</p>
-<p align="center"><strong>4 public research preprints</strong> · <a href="https://zenodo.org/records/21853302">V4 Zenodo DOI: 10.5281/zenodo.21853302</a> · <a href="https://arxiv.org/abs/2603.02240">arXiv:2603.02240</a> · <a href="https://arxiv.org/abs/2603.14588">arXiv:2603.14588</a> · <a href="https://arxiv.org/abs/2604.04514">arXiv:2604.04514</a></p>
+<p align="center"><strong>4 public research records</strong> · V4 preprint: <a href="https://zenodo.org/records/21853302">Zenodo 21853302</a> (<a href="https://doi.org/10.5281/zenodo.21853302">DOI 10.5281/zenodo.21853302</a>) · prior arXiv preprints: <a href="https://arxiv.org/abs/2603.02240">2603.02240</a> · <a href="https://arxiv.org/abs/2603.14588">2603.14588</a> · <a href="https://arxiv.org/abs/2604.04514">2604.04514</a>. The V4 arXiv submission is pending public announcement.</p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/v4.0.0-Current_Release-2ea44f?style=for-the-badge&logo=checkmarx&logoColor=white" alt="v4.0.0 — Current Release"/></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/v4.0.1-Current_Release-2ea44f?style=for-the-badge&logo=checkmarx&logoColor=white" alt="v4.0.1 — Current Release"/></a>
   <a href="https://zenodo.org/records/21853302"><img src="https://img.shields.io/badge/Zenodo-10.5281%2Fzenodo.21853302-1682D4?style=for-the-badge&logo=zenodo&logoColor=white" alt="V4 paper on Zenodo: 10.5281/zenodo.21853302"/></a>
+  <a href="https://arxiv.org/abs/2603.14588"><img src="https://img.shields.io/badge/arXiv-2603.14588-b31b1b?style=for-the-badge&logo=arxiv&logoColor=white" alt="arXiv Paper"/></a>
   <a href="#three-surfaces-proxy--mcp-tools--skill"><img src="https://img.shields.io/badge/Proxy_|_MCP_|_Skill-22c55e?style=for-the-badge" alt="Three Surfaces: Proxy, MCP Tools, Skill"/></a>
   <a href="https://pypi.org/project/superlocalmemory/"><img src="https://img.shields.io/pypi/v/superlocalmemory?style=for-the-badge&logo=pypi&logoColor=white" alt="PyPI"/></a>
   <a href="https://www.npmjs.com/package/superlocalmemory"><img src="https://img.shields.io/npm/v/superlocalmemory?style=for-the-badge&logo=npm&logoColor=white" alt="npm"/></a>
@@ -60,7 +61,7 @@ SuperLocalMemory V4 combines conventional dense and lexical retrieval with graph
 
 **Memory with a sense of time.** SLM does not only store *what* an agent learned — it records *when*. Every fact carries ingestion timing and provenance; recall runs a dedicated temporal candidate channel alongside semantic, lexical, and associative retrieval; scenes and entity timelines reconstruct sequence; and the lifecycle lets neglected memory decay and self-archive instead of growing without bound. Time is a first-class ranking and lifecycle signal rather than a timestamp column an agent never reads — which is what lets a long-lived agent reason about how its context changed, not only what it currently holds.
 
-**What V4.0.0 ships.** V4 is a *governed* local-first control plane — every canonical write is admitted, policy-authorized, tracked as durable per-store obligations (lexical, temporal, vector), and sealed by a completion manifest, so it is either fully applied or explicitly marked degraded, never silently half-done. Flagship surfaces in this release:
+**What V4.0.1 ships.** V4 is a *governed* local-first control plane — every canonical write is admitted, policy-authorized, tracked as durable per-store obligations (lexical, temporal, vector), and sealed by a completion manifest, so it is either fully applied or explicitly marked degraded, never silently half-done. Flagship surfaces in this release:
 
 - **[SLM-Mesh](#slm-mesh-cross-session--cross-machine-coordination)** — authenticated cross-session and cross-machine peer coordination (messages, locks, shared state, inbox/outbox, optional discovery). Coordination only — not automatic replicated memory.
 - **Multi-scope memory & profiles** — workspaces (profiles) plus `personal` / `shared` / `global` scopes; cross-profile recall is default-deny.
@@ -695,9 +696,9 @@ runtime capability is enabled and healthy. See [CHANGELOG.md](CHANGELOG.md) for
 the complete release history.
 ## Research Papers
 
-SuperLocalMemory is backed by four public preprints (2026):
+SuperLocalMemory has a V4 Zenodo preprint and three earlier arXiv preprints (2026):
 
-- **The Governed Memory Operating System (V4):** [Zenodo 21853302](https://zenodo.org/records/21853302) · DOI [`10.5281/zenodo.21853302`](https://doi.org/10.5281/zenodo.21853302). The arXiv submission is pending public announcement; this entry will be updated once arXiv assigns its public identifier.
+- **SuperLocalMemory 4.0: The Governed Memory Operating System for AI Agents:** [Zenodo 21853302](https://zenodo.org/records/21853302) · [DOI 10.5281/zenodo.21853302](https://doi.org/10.5281/zenodo.21853302). The arXiv submission is pending public announcement.
 - **The Living Brain (V3.3):** [arXiv:2604.04514](https://arxiv.org/abs/2604.04514) · [Zenodo 19435120](https://zenodo.org/records/19435120)
 - **Information-Geometric Foundations (V3):** [arXiv:2603.14588](https://arxiv.org/abs/2603.14588) · [Zenodo 19038659](https://zenodo.org/records/19038659)
 - **Trust & Behavioral Foundations (V2):** [arXiv:2603.02240](https://arxiv.org/abs/2603.02240) · [Zenodo 18709670](https://zenodo.org/records/18709670)

--- a/copilot-plugin/.github/agents/slm-governance-advisor.agent.md
+++ b/copilot-plugin/.github/agents/slm-governance-advisor.agent.md
@@ -9,7 +9,7 @@ description: >
 tools: recall, search, remember, update_memory, list_recent, Read, Bash
 model: inherit
 target: vscode
-version: "4.0.0"
+version: "4.0.1"
 ---
 
 # Role
@@ -79,4 +79,4 @@ slm-scope · slm-governance · slm-profile · slm-remember · slm-recall
 # What NOT to do
 Never session_init twice; never forget without dry-run preview; never store secrets; never bypass role checks; never claim an erasure succeeded without verifying via recall.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/agents/slm-loop-runner.agent.md
+++ b/copilot-plugin/.github/agents/slm-loop-runner.agent.md
@@ -11,7 +11,7 @@ description: >
 tools: Bash, slm_recall, slm_remember, Read
 model: inherit
 target: vscode
-version: "4.0.0"
+version: "4.0.1"
 ---
 
 # Role
@@ -70,4 +70,4 @@ assessment. The gate is the authority.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/agents/slm-memory-advisor.agent.md
+++ b/copilot-plugin/.github/agents/slm-memory-advisor.agent.md
@@ -8,7 +8,7 @@ description: >
 tools: session_init, recall, search, remember, update_memory, forget, list_recent, Read
 model: inherit
 target: vscode
-version: "4.0.0"
+version: "4.0.1"
 ---
 
 # Role
@@ -48,4 +48,4 @@ slm-recall · slm-remember · slm-session · slm-scope · slm-profile · slm-gov
 # What NOT to do
 Never session_init twice; never forget dry_run=False without reporting preview; never dump a whole file into remember; never invent a memory; never claim "saved" without success:true / clean CLI exit; never bypass scope or governance restrictions.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/agents/slm-optimize-advisor.agent.md
+++ b/copilot-plugin/.github/agents/slm-optimize-advisor.agent.md
@@ -9,7 +9,7 @@ description: >
 tools: slm_compress, slm_retrieve, slm_cache_set, slm_cache_get, slm_optimize_stats, Read, Bash
 model: inherit
 target: vscode
-version: "4.0.0"
+version: "4.0.1"
 ---
 
 # Role
@@ -43,4 +43,4 @@ slm-compress · slm-cache · slm-status · slm-profile
 # What NOT to do
 Never compress code-for-edit/JSON-to-parse/<500 chars; never store secrets/ccr_ids; never let optimize failure block/alter the task; never claim a specific savings %; never carry ccr_ids across profile switches.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/copilot-instructions.md
+++ b/copilot-plugin/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 <!-- SLM-START -->
-<!-- SuperLocalMemory v4.0.0 — managed block. Edit outside these markers; this section is regenerated. -->
+<!-- SuperLocalMemory v4.0.1 — managed block. Edit outside these markers; this section is regenerated. -->
 
-<!-- BEGIN SuperLocalMemory v4.0.0 -->
+<!-- BEGIN SuperLocalMemory v4.0.1 -->
 
 ## SuperLocalMemory (SLM) — Agent Rules
 
@@ -42,8 +42,8 @@ slm-recall · slm-remember · slm-session · slm-status · slm-cache · slm-comp
 ### Subagents
 slm-memory-advisor (memory decisions, session hygiene, scope/profile guidance) · slm-optimize-advisor (context compression + KV cache) · slm-governance-advisor (scope/roles/compliance/GDPR)
 
-<!-- END SuperLocalMemory v4.0.0 -->
+<!-- END SuperLocalMemory v4.0.1 -->
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later
 
 <!-- SLM-END -->

--- a/copilot-plugin/.github/prompts/slm-cache.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-cache.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-cache
 description: KV cache for repeated reads — call slm_cache_get(key) first; on a miss do the expensive operation then slm_cache_set(key, value, ttl_seconds) to store it; on a hit use the returned value directly; always fail-open (hit:false on any error, never raises); saves tokens when the same file, query result, or tool output is read more than once in a session.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - slm_cache_set
@@ -149,4 +149,4 @@ These subcommands control daemon-level cache settings. They do not read or write
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/prompts/slm-compress.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-compress.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-compress
 description: Compress large text, tool output, or transcripts to reduce context-window usage while keeping the full 1M window intact — call slm_compress(content, mode, reversible, ttl_seconds) to shrink content; if the result is lossy a ccr_id is returned so you can call slm_retrieve(ccr_id) later to recover the exact original; always fail-open (ok:false → continue with the original).
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - slm_compress
@@ -151,4 +151,4 @@ Content over 1 MB (1 000 000 bytes UTF-8) is processed but `reversible` is force
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/prompts/slm-governance.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-governance.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-governance
 description: Enterprise compliance and governed workspace behavior for SuperLocalMemory. Covers role-based access (admin/member/viewer), retention policies, audit trail, GDPR data export/erase, and how agents must behave when operating under workspace governance. Requires power MCP profile for audit/retention tools. Agents must never bypass governance controls.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - audit_trail
@@ -246,4 +246,4 @@ Before running any destructive operation (`forget`, `compact_memories`):
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/copilot-plugin/.github/prompts/slm-graph.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-graph.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-graph
 description: >
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - build_code_graph
@@ -306,4 +306,4 @@ profile. See `slm-profile` for the full profile switching workflow.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/prompts/slm-loop.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-loop.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-loop
 description: Run gate-verified bounded loops with SuperLocalMemory as the durable ledger. Use when a task has a checkable acceptance condition (tests, schema, lint, reconciliation) and you must iterate until an INDEPENDENT gate passes — never stopping just because the agent believes it is done. `slm loop demo` runs a keyless convergence demo; `slm loop history` and `slm loop show <run_id>` inspect past runs whose every lap is persisted as queryable SLM memory (tag `loop:<name>`). Terminal statuses are DONE / HALT / PAUSE / KILLED / ERROR — report them exactly, never converting HALT/PAUSE/ERROR into success.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - Bash
@@ -99,4 +99,4 @@ paused, name the approval needed; when errored, quote the short detail.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/.github/prompts/slm-mesh.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-mesh.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-mesh
 description: Cross-session peer coordination via the SLM mesh network. Lets multiple AI agent sessions on the same machine discover each other, send messages, share lightweight state, and lock files to avoid conflicts. Requires full, power, or mesh MCP profile. All 8 tools are MCP-only — there is no CLI fallback.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - mesh_summary
@@ -282,4 +282,4 @@ mesh availability.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/copilot-plugin/.github/prompts/slm-profile.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-profile.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-profile
 description: Workspace isolation and runtime profile switching for SuperLocalMemory. Each profile is a fully independent memory namespace — separate facts, code graphs, and tool sets. Use switch_profile (MCP, requires code/full/power profile) to change the active workspace without restarting. Check the active profile with slm status. Required when working across multiple projects, clients, or tenants.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - switch_profile
@@ -140,4 +140,4 @@ Name them differently in your MCP config (e.g. `superlocalmemory-personal` and
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/copilot-plugin/.github/prompts/slm-recall.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-recall.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-recall
 description: Search and retrieve facts, decisions, and past context from SuperLocalMemory. Use when the user asks to recall, find, search, or "what did we decide/say about X". Triggers multi-channel semantic retrieval with reranking; always call before storing anything new.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - recall
@@ -236,4 +236,4 @@ before recalling, then switch back. See `slm-profile` for workspace switching.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/copilot-plugin/.github/prompts/slm-remember.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-remember.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-remember
 description: Capture durable facts, decisions, constraints, and gotchas into SuperLocalMemory. Use when the user says "remember that", "save this decision", "note this constraint", or when a session produces a conclusion worth persisting across sessions. Always recall first to avoid duplicates.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - remember
@@ -237,4 +237,4 @@ different workspace, use `switch_profile` first. See `slm-profile`.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/copilot-plugin/.github/prompts/slm-scope.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-scope.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-scope
 description: Controls memory visibility across profiles — personal (private, default), shared (selected profiles), or global (all profiles on this machine). Default is always personal. Only change scope when the user explicitly asks to share a memory across workspaces. Works with both remember (write scope) and recall (read scope flags).
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - remember
@@ -173,4 +173,4 @@ to review the impact. See `slm-remember` for the full deletion discipline.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/copilot-plugin/.github/prompts/slm-session.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-session.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-session
 description: Manage SuperLocalMemory session lifecycle — call session_init once at the start of every fresh session to load relevant project context and get a session_id; call close_session when work is meaningfully complete to commit temporal summaries. Correct lifecycle hygiene is what makes SLM's learning loop work.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - session_init
@@ -227,4 +227,4 @@ explicitly and call `recall` with `include_global`/`include_shared` after
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/copilot-plugin/.github/prompts/slm-status.prompt.md
+++ b/copilot-plugin/.github/prompts/slm-status.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: slm-status
 description: Health and optimization stats for SuperLocalMemory — call slm_optimize_stats() for live compression and cache counters (compress_runs, tokens_saved_compress, cache_proxy_hits, cache_proxy_misses, cache_kv_hits, cache_kv_misses); run slm status [--json] for system state (mode, profile, DB size, fact/entity/edge counts) and slm doctor [--json] for preflight including the "Optimize (Surface B)" health line; use together to confirm optimization is actually saving tokens.
-version: "4.0.0"
+version: "4.0.1"
 agent: agent
 tools:
   - slm_optimize_stats
@@ -166,4 +166,4 @@ multi-profile setup. To switch the active profile, see `slm-profile`.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/README.md
+++ b/copilot-plugin/README.md
@@ -1,4 +1,4 @@
-# SuperLocalMemory — GitHub Copilot plugin (v4.0.0)
+# SuperLocalMemory — GitHub Copilot plugin (v4.0.1)
 
 Empowers GitHub Copilot (VS Code, Visual Studio, JetBrains, Eclipse, CLI) with SuperLocalMemory as its long-term brain — at parity with the Claude and Codex plugins.
 
@@ -19,4 +19,4 @@ Merges into your existing project without overwriting:
 
 MCP works on every Copilot IDE at GA. Prompts, agents, and hooks are additive and degrade gracefully where an IDE does not yet support them (hooks are VS Code Preview as of 2026). SLM lifecycle also has an instruction-level fallback in `copilot-instructions.md`, so memory works even without hooks.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/copilot-plugin/_GENERATED.md
+++ b/copilot-plugin/_GENERATED.md
@@ -2,7 +2,7 @@
 
 Built by `scripts/build-copilot-plugin.mjs` from the single source in `plugin-src/` (+ `ide/configs/vscode-copilot-mcp.json`, `plugin/CLAUDE.md`). Version stamped from `plugin-src/manifest.json`.
 
-Version: **4.0.0**
+Version: **4.0.1**
 
 | Output | Source |
 |---|---|

--- a/docs/security/dependency-audit-exceptions.md
+++ b/docs/security/dependency-audit-exceptions.md
@@ -5,13 +5,16 @@ listed below. Each exception must name the transitive dependency path, explain
 why the vulnerable API is not reachable from untrusted input, and be removed
 as soon as a stable patched release is available.
 
-**Status as of 2026-08-08: both remaining exceptions are actionable.** A stable
-release beyond each affected version is published on PyPI (versions verified
-against the PyPI JSON API on 2026-08-08). Neither exception below is
-blocked on upstream any more; each is blocked only on us scheduling and testing
-the upgrade. The non-reachability arguments remain accurate and unchanged — they
-are why these are exceptions rather than incidents.
+**Status as of 2026-08-09:** the NLTK exception is retired in 4.0.1. The two
+remaining exceptions are actionable: stable releases beyond the affected
+versions are available, so removal is blocked only on our scheduled, verified
+native-stack upgrade. Their non-reachability arguments remain accurate and are
+why these are exceptions rather than incidents.
 
+## Retired: PYSEC-2026-597 — NLTK
+
+SuperLocalMemory 4.0.1 pins `nltk==3.10.0`, above the affected 3.9.4 release.
+The CI suppression was removed with that upgrade.
 ## PYSEC-2026-3447 — setuptools 81.0.0
 
 - **Dependency path:** `superlocalmemory -> torch 2.11.0 -> setuptools <82`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superlocalmemory",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superlocalmemory",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superlocalmemory",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Local-first agent memory with MCP and an agent-native CLI. Documented clients include Claude Code, Cursor, and Windsurf.",
   "keywords": [
     "ai-memory",

--- a/plugin-src/agents/slm-governance-advisor.md
+++ b/plugin-src/agents/slm-governance-advisor.md
@@ -77,4 +77,4 @@ slm-scope · slm-governance · slm-profile · slm-remember · slm-recall
 # What NOT to do
 Never session_init twice; never forget without dry-run preview; never store secrets; never bypass role checks; never claim an erasure succeeded without verifying via recall.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/agents/slm-loop-runner.md
+++ b/plugin-src/agents/slm-loop-runner.md
@@ -68,4 +68,4 @@ assessment. The gate is the authority.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/agents/slm-memory-advisor.md
+++ b/plugin-src/agents/slm-memory-advisor.md
@@ -46,4 +46,4 @@ slm-recall · slm-remember · slm-session · slm-scope · slm-profile · slm-gov
 # What NOT to do
 Never session_init twice; never forget dry_run=False without reporting preview; never dump a whole file into remember; never invent a memory; never claim "saved" without success:true / clean CLI exit; never bypass scope or governance restrictions.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/agents/slm-optimize-advisor.md
+++ b/plugin-src/agents/slm-optimize-advisor.md
@@ -41,4 +41,4 @@ slm-compress · slm-cache · slm-status · slm-profile
 # What NOT to do
 Never compress code-for-edit/JSON-to-parse/<500 chars; never store secrets/ccr_ids; never let optimize failure block/alter the task; never claim a specific savings %; never carry ccr_ids across profile switches.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/manifest.json
+++ b/plugin-src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0",
+  "version": "4.0.1",
   "pluginName": "superlocalmemory",
   "displayName": "SuperLocalMemory",
   "repository": "https://github.com/qualixar/superlocalmemory",

--- a/plugin-src/requirements.txt
+++ b/plugin-src/requirements.txt
@@ -1,1 +1,1 @@
-superlocalmemory==4.0.0
+superlocalmemory==4.0.1

--- a/plugin-src/rules/AGENTS.md
+++ b/plugin-src/rules/AGENTS.md
@@ -128,4 +128,4 @@ When the SLM MCP server is unavailable, use these CLI equivalents:
 - **slm-optimize-advisor** — context compression and KV cache
 - **slm-governance-advisor** — scope/role compliance, retention policies, GDPR
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/rules/CLAUDE.md.fragment
+++ b/plugin-src/rules/CLAUDE.md.fragment
@@ -1,4 +1,4 @@
-<!-- BEGIN SuperLocalMemory v4.0.0 -->
+<!-- BEGIN SuperLocalMemory v4.0.1 -->
 
 ## SuperLocalMemory (SLM) — Agent Rules
 
@@ -39,6 +39,6 @@ slm-recall · slm-remember · slm-session · slm-status · slm-cache · slm-comp
 ### Subagents
 slm-memory-advisor (memory decisions, session hygiene, scope/profile guidance) · slm-optimize-advisor (context compression + KV cache) · slm-governance-advisor (scope/roles/compliance/GDPR)
 
-<!-- END SuperLocalMemory v4.0.0 -->
+<!-- END SuperLocalMemory v4.0.1 -->
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/skills/slm-cache/SKILL.md
+++ b/plugin-src/skills/slm-cache/SKILL.md
@@ -145,4 +145,4 @@ These subcommands control daemon-level cache settings. They do not read or write
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/skills/slm-compress/SKILL.md
+++ b/plugin-src/skills/slm-compress/SKILL.md
@@ -147,4 +147,4 @@ Content over 1 MB (1 000 000 bytes UTF-8) is processed but `reversible` is force
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/skills/slm-governance/SKILL.md
+++ b/plugin-src/skills/slm-governance/SKILL.md
@@ -245,4 +245,4 @@ Before running any destructive operation (`forget`, `compact_memories`):
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin-src/skills/slm-graph/SKILL.md
+++ b/plugin-src/skills/slm-graph/SKILL.md
@@ -311,4 +311,4 @@ profile. See `slm-profile` for the full profile switching workflow.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/skills/slm-loop/SKILL.md
+++ b/plugin-src/skills/slm-loop/SKILL.md
@@ -96,4 +96,4 @@ paused, name the approval needed; when errored, quote the short detail.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin-src/skills/slm-mesh/SKILL.md
+++ b/plugin-src/skills/slm-mesh/SKILL.md
@@ -279,4 +279,4 @@ mesh availability.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin-src/skills/slm-profile/SKILL.md
+++ b/plugin-src/skills/slm-profile/SKILL.md
@@ -145,4 +145,4 @@ Name them differently in your MCP config (e.g. `superlocalmemory-personal` and
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin-src/skills/slm-recall/SKILL.md
+++ b/plugin-src/skills/slm-recall/SKILL.md
@@ -236,4 +236,4 @@ before recalling, then switch back. See `slm-profile` for workspace switching.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin-src/skills/slm-remember/SKILL.md
+++ b/plugin-src/skills/slm-remember/SKILL.md
@@ -238,4 +238,4 @@ different workspace, use `switch_profile` first. See `slm-profile`.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin-src/skills/slm-scope/SKILL.md
+++ b/plugin-src/skills/slm-scope/SKILL.md
@@ -173,4 +173,4 @@ to review the impact. See `slm-remember` for the full deletion discipline.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin-src/skills/slm-session/SKILL.md
+++ b/plugin-src/skills/slm-session/SKILL.md
@@ -227,4 +227,4 @@ explicitly and call `recall` with `include_global`/`include_shared` after
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin-src/skills/slm-status/SKILL.md
+++ b/plugin-src/skills/slm-status/SKILL.md
@@ -163,4 +163,4 @@ multi-profile setup. To switch the active profile, see `slm-profile`.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -15,5 +15,5 @@
   "mcpServers": "./.mcp.json",
   "name": "superlocalmemory",
   "repository": "https://github.com/qualixar/superlocalmemory",
-  "version": "4.0.0"
+  "version": "4.0.1"
 }

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- BEGIN SuperLocalMemory v4.0.0 -->
+<!-- BEGIN SuperLocalMemory v4.0.1 -->
 
 ## SuperLocalMemory (SLM) — Agent Rules
 
@@ -39,6 +39,6 @@ slm-recall · slm-remember · slm-session · slm-status · slm-cache · slm-comp
 ### Subagents
 slm-memory-advisor (memory decisions, session hygiene, scope/profile guidance) · slm-optimize-advisor (context compression + KV cache) · slm-governance-advisor (scope/roles/compliance/GDPR)
 
-<!-- END SuperLocalMemory v4.0.0 -->
+<!-- END SuperLocalMemory v4.0.1 -->
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/agents/slm-governance-advisor.md
+++ b/plugin/agents/slm-governance-advisor.md
@@ -77,4 +77,4 @@ slm-scope · slm-governance · slm-profile · slm-remember · slm-recall
 # What NOT to do
 Never session_init twice; never forget without dry-run preview; never store secrets; never bypass role checks; never claim an erasure succeeded without verifying via recall.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/agents/slm-loop-runner.md
+++ b/plugin/agents/slm-loop-runner.md
@@ -68,4 +68,4 @@ assessment. The gate is the authority.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/agents/slm-memory-advisor.md
+++ b/plugin/agents/slm-memory-advisor.md
@@ -46,4 +46,4 @@ slm-recall · slm-remember · slm-session · slm-scope · slm-profile · slm-gov
 # What NOT to do
 Never session_init twice; never forget dry_run=False without reporting preview; never dump a whole file into remember; never invent a memory; never claim "saved" without success:true / clean CLI exit; never bypass scope or governance restrictions.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/agents/slm-optimize-advisor.md
+++ b/plugin/agents/slm-optimize-advisor.md
@@ -41,4 +41,4 @@ slm-compress · slm-cache · slm-status · slm-profile
 # What NOT to do
 Never compress code-for-edit/JSON-to-parse/<500 chars; never store secrets/ccr_ids; never let optimize failure block/alter the task; never claim a specific savings %; never carry ccr_ids across profile switches.
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/requirements.txt
+++ b/plugin/requirements.txt
@@ -1,1 +1,1 @@
-superlocalmemory==4.0.0
+superlocalmemory==4.0.1

--- a/plugin/skills/slm-cache/SKILL.md
+++ b/plugin/skills/slm-cache/SKILL.md
@@ -145,4 +145,4 @@ These subcommands control daemon-level cache settings. They do not read or write
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/skills/slm-compress/SKILL.md
+++ b/plugin/skills/slm-compress/SKILL.md
@@ -147,4 +147,4 @@ Content over 1 MB (1 000 000 bytes UTF-8) is processed but `reversible` is force
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/skills/slm-governance/SKILL.md
+++ b/plugin/skills/slm-governance/SKILL.md
@@ -245,4 +245,4 @@ Before running any destructive operation (`forget`, `compact_memories`):
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin/skills/slm-graph/SKILL.md
+++ b/plugin/skills/slm-graph/SKILL.md
@@ -311,4 +311,4 @@ profile. See `slm-profile` for the full profile switching workflow.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/skills/slm-loop/SKILL.md
+++ b/plugin/skills/slm-loop/SKILL.md
@@ -96,4 +96,4 @@ paused, name the approval needed; when errored, quote the short detail.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/plugin/skills/slm-mesh/SKILL.md
+++ b/plugin/skills/slm-mesh/SKILL.md
@@ -279,4 +279,4 @@ mesh availability.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin/skills/slm-profile/SKILL.md
+++ b/plugin/skills/slm-profile/SKILL.md
@@ -145,4 +145,4 @@ Name them differently in your MCP config (e.g. `superlocalmemory-personal` and
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin/skills/slm-recall/SKILL.md
+++ b/plugin/skills/slm-recall/SKILL.md
@@ -236,4 +236,4 @@ before recalling, then switch back. See `slm-profile` for workspace switching.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin/skills/slm-remember/SKILL.md
+++ b/plugin/skills/slm-remember/SKILL.md
@@ -238,4 +238,4 @@ different workspace, use `switch_profile` first. See `slm-profile`.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin/skills/slm-scope/SKILL.md
+++ b/plugin/skills/slm-scope/SKILL.md
@@ -173,4 +173,4 @@ to review the impact. See `slm-remember` for the full deletion discipline.
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin/skills/slm-session/SKILL.md
+++ b/plugin/skills/slm-session/SKILL.md
@@ -227,4 +227,4 @@ explicitly and call `recall` with `include_global`/`include_shared` after
 
 ---
 
-*SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later*
+*SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later*

--- a/plugin/skills/slm-status/SKILL.md
+++ b/plugin/skills/slm-status/SKILL.md
@@ -163,4 +163,4 @@ multi-profile setup. To switch the active profile, see `slm-profile`.
 
 ---
 
-SuperLocalMemory v4.0.0 · Qualixar · AGPL-3.0-or-later
+SuperLocalMemory v4.0.1 · Qualixar · AGPL-3.0-or-later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "superlocalmemory"
-version = "4.0.0"
+version = "4.0.1"
 description = "Local-first agent memory with auditable hybrid retrieval"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -90,8 +90,8 @@ dependencies = [
     # the ~560MB model downloads on first setup/warmup (fail-open). Verified the
     # pin does NOT disturb the transformers/torch/numpy pins above.
     "llmlingua==0.2.2",
-    # LLMLingua pulls NLTK transitively. Pin the patched release so clean
-    # installs cannot resolve to the vulnerable 3.9.x line.
+    # LLMLingua pulls NLTK transitively. Pin above the disclosed traversal
+    # advisories so clean installs cannot resolve to the vulnerable 3.9.x line.
     "nltk==3.10.0",
 ]
 

--- a/src/superlocalmemory/__init__.py
+++ b/src/superlocalmemory/__init__.py
@@ -32,7 +32,7 @@ if "OMP_NUM_THREADS" not in os.environ:
     os.environ["OMP_NUM_THREADS"] = "2"
 # ---------------------------------------------------------------------------
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 _REQUIRED_VERSIONS = {
     "sentence_transformers": "5.3.0",

--- a/src/superlocalmemory/server/ui.py
+++ b/src/superlocalmemory/server/ui.py
@@ -43,7 +43,7 @@ sys.path = [p for p in sys.path if p not in ("", _script_dir)]
 try:
     from fastapi import FastAPI
     from fastapi.staticfiles import StaticFiles
-    from fastapi.responses import HTMLResponse
+    from fastapi.responses import HTMLResponse, RedirectResponse
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.middleware.gzip import GZipMiddleware
     import uvicorn
@@ -73,7 +73,7 @@ def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     application = FastAPI(
         title="SuperLocalMemory V4 UI Server",
-        description="Memory Dashboard with V4 Engine, Trust, Learning, and Compliance",
+        description="Governed memory dashboard with trust, learning, and compliance controls.",
         version=SLM_VERSION,
         docs_url="/api/docs",
         redoc_url="/api/redoc",
@@ -232,6 +232,11 @@ def create_app() -> FastAPI:
                 "</body></html>"
             )
         return index_path.read_text()
+
+    @application.get("/favicon.ico", include_in_schema=False)
+    async def favicon():
+        """Serve the packaged SVG icon for browsers that request favicon.ico."""
+        return RedirectResponse(url="/static/favicon.svg", status_code=307)
 
     @application.get("/health")
     async def health_check():

--- a/src/superlocalmemory/server/unified_daemon.py
+++ b/src/superlocalmemory/server/unified_daemon.py
@@ -3467,7 +3467,7 @@ def _register_dashboard_routes(application: FastAPI) -> None:
     _data_io_mod.ws_manager = ws_manager
 
     # Root page
-    from fastapi.responses import HTMLResponse, JSONResponse
+    from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
     # v3.4.23: /api/version — dashboard polls this to detect daemon upgrades
     # and auto-reload stale tabs (see ui/js/core.js::checkVersionFingerprint).
@@ -3530,6 +3530,11 @@ def _register_dashboard_routes(application: FastAPI) -> None:
         # days, but we want zero caching surprises during development).
         html = index_path.read_text()
         return html.replace("__SLM_VERSION__", _SLM_VERSION)
+
+    @application.get("/favicon.ico", include_in_schema=False)
+    async def favicon():
+        """Serve the packaged SVG icon for browsers that request favicon.ico."""
+        return RedirectResponse(url="/static/favicon.svg", status_code=307)
 
 def _register_daemon_routes(application: FastAPI) -> None:
     """Add daemon-specific routes for CLI integration."""
@@ -3695,7 +3700,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
             "active_profile": profile_snapshot.profile_id,
             "profile_generation": profile_snapshot.generation,
             # Wave-3: operational failure counts (visible to all team members)
-            **_ops_failure_counts(engine),
+            **_ops_failure_counts(engine, application),
             # issue #107: does this daemon's *imported* code still match the
             # installed distribution? ``version`` above reports what this
             # process loaded, which is self-consistent and therefore cannot
@@ -4271,7 +4276,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
             # "Optimizing memory…" line from this. Defaults to idle before start.
             "self_heal": globals().get("_SELF_HEAL_STATUS", {"state": "idle"}),
             # Wave-3: operational failure counts (dead-letter, degraded, stalled)
-            **_ops_failure_counts(engine),
+            **_ops_failure_counts(engine, application),
         }
 
     @application.get("/api/v3/components")
@@ -4870,7 +4875,7 @@ def _terminalize_orphan_operation(engine, operation_id: str) -> None:
         )
 
 
-def _ops_failure_counts(engine) -> dict:
+def _ops_failure_counts(engine, application) -> dict:
     """Return Wave-3 operational failure counts for /status and /health.
 
     Always returns a dict (never raises). Counts default to 0 on any error.
@@ -4885,6 +4890,9 @@ def _ops_failure_counts(engine) -> dict:
         "writer_stalled_op_id": None,
         "writer_stalled_age_s": None,
     }
+    # ``application`` is explicitly passed by the route handlers.  There is no
+    # module-global FastAPI app; relying on one silently returned all-zero
+    # counters whenever this helper caught the resulting NameError.
     # Writer stall info from canonical coordinator
     try:
         writer_runtime = getattr(application.state, "canonical_remember_runtime", None)

--- a/src/superlocalmemory/ui/index.html
+++ b/src/superlocalmemory/ui/index.html
@@ -7,8 +7,8 @@
          compares this to /api/version and hard-reloads + clears localStorage
          on mismatch, so the browser cannot show stale UI after an upgrade. -->
     <meta name="slm-version" content="__SLM_VERSION__">
-    <title>SuperLocalMemory V3 — Dashboard</title>
-    <link rel="icon" type="image/svg+xml" href="static/favicon.svg">
+    <title>SuperLocalMemory V4 — Dashboard</title>
+    <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 
     <!-- Bootstrap CSS (vendored locally v3.4.21 — no CDN calls, works offline) -->
     <link href="static/vendor/bootstrap.min.css" rel="stylesheet">

--- a/tests/test_cli/test_release_help_surface.py
+++ b/tests/test_cli/test_release_help_surface.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from superlocalmemory import __version__
 
 
 _ROOT_COMMANDS = (
@@ -80,7 +81,7 @@ def test_root_help_identifies_v4_without_changing_version(
     )
 
     assert result.returncode == 0, result.stderr
-    assert "SuperLocalMemory V4 (4.0.0)" in result.stdout
+    assert f"SuperLocalMemory V4 ({__version__})" in result.stdout
     assert "SuperLocalMemory V3" not in result.stdout
 
 

--- a/tests/test_resilience/test_ops_list_failed.py
+++ b/tests/test_resilience/test_ops_list_failed.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -155,6 +156,33 @@ class TestListFailedOperationsBasic:
         assert len(result["degraded_manifests"]) == 1
         assert len(result["exhausted_obligations"]) == 1
         assert result["total"] == 3
+
+
+class TestOpsStatusFailureCounts:
+    def test_status_helper_reports_persisted_failure_surfaces(self, tmp_path):
+        """The daemon status route must not silently report zero for a bad DB."""
+        from superlocalmemory.server.unified_daemon import _ops_failure_counts
+
+        db_path = tmp_path / "memory.db"
+        conn = sqlite3.connect(db_path)
+        _apply_migrations(conn)
+        _seed_dead_letter(conn, "default", "dlq-status")
+        _seed_degraded_manifest(conn, "default", "deg-status")
+        _seed_exhausted_obligation(conn, "default", "exh-status", attempts=10)
+        conn.close()
+
+        application = SimpleNamespace(
+            state=SimpleNamespace(
+                config=SimpleNamespace(db_path=db_path),
+                canonical_remember_runtime=None,
+                write_coordinator=None,
+            )
+        )
+        counts = _ops_failure_counts(engine=None, application=application)
+
+        assert counts["dead_letter_count"] == 1
+        assert counts["degraded_operations"] == 1
+        assert counts["exhausted_obligations"] == 1
 
 
 class TestListFailedOperationsProfileFilter:

--- a/tests/test_ui/test_brain_render.py
+++ b/tests/test_ui/test_brain_render.py
@@ -126,6 +126,15 @@ def test_brain_js_has_report_outcome_and_reset_endpoints() -> None:
     assert "/api/learning/migrate-legacy" in js
 
 
+def test_brain_js_exposes_safe_manual_cold_start_training() -> None:
+    """A qualified cold-start user can train without discovering an API."""
+    js = _UI_JS.read_text(encoding="utf-8")
+    assert "Manual training trigger" in js
+    assert "Train model now" in js
+    assert "Enough signals collected. You can train the model now" in js
+    assert "postRetrain(hasLegacy)" in js
+
+
 def test_brain_js_no_developer_view_render_path() -> None:
     """renderDeveloper / kvTable removed — one honest view only."""
     js = _UI_JS.read_text(encoding="utf-8")

--- a/tests/ui/test_dashboard_release_identity.mjs
+++ b/tests/ui/test_dashboard_release_identity.mjs
@@ -1,0 +1,43 @@
+/** The packaged dashboard must identify and brand the shipped V4 release. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '../..');
+const html = readFileSync(
+  join(root, 'src/superlocalmemory/ui/index.html'),
+  'utf8',
+);
+const daemon = readFileSync(
+  join(root, 'src/superlocalmemory/server/unified_daemon.py'),
+  'utf8',
+);
+const standaloneUi = readFileSync(
+  join(root, 'src/superlocalmemory/server/ui.py'),
+  'utf8',
+);
+
+describe('dashboard release identity', () => {
+  it('identifies the dashboard as V4 and declares an absolute SVG favicon', () => {
+    assert.match(html, /<title>SuperLocalMemory V4 — Dashboard<\/title>/);
+    assert.match(html, /href="\/static\/favicon\.svg"/);
+    assert.doesNotMatch(html, /<title>SuperLocalMemory V3 — Dashboard<\/title>/);
+  });
+
+  it('provides the conventional favicon route without duplicating the asset', () => {
+    assert.match(daemon, /@application\.get\("\/favicon\.ico", include_in_schema=False\)/);
+    assert.match(daemon, /RedirectResponse\(url="\/static\/favicon\.svg", status_code=307\)/);
+  });
+
+  it('keeps the unified and standalone dashboard fallbacks on the V4 identity', () => {
+    for (const server of [daemon, standaloneUi]) {
+      assert.match(server, /SuperLocalMemory V4/);
+      assert.doesNotMatch(server, /<title>SuperLocalMemory V3<\/title>/);
+      assert.match(server, /@application\.get\("\/favicon\.ico", include_in_schema=False\)/);
+    }
+  });
+});

--- a/uv.lock
+++ b/uv.lock
@@ -3113,7 +3113,7 @@ wheels = [
 
 [[package]]
 name = "superlocalmemory"
-version = "4.0.0"
+version = "4.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## V4.0.1\n\nPatch release built on the published V4.0.0 snapshot.\n\n- Corrects dashboard V4 identity and favicon delivery.\n- Exposes accurate operational failure counts and adds the manual learning cold-start regression.\n- Aligns Python, npm, Claude, Codex, and Copilot package metadata at 4.0.1.\n- Records the Zenodo V4 preprint citation and maintains the audited V4 documentation contract.\n- Retires the NLTK audit suppression with the verified patched pin.\n\nLocal release gate: 128 focused Python tests, 4 dashboard tests, plugin parity, lock and CFF validation.\n\nMerge method: rebase, preserving the repository's required linear history.