### PR TITLE
test: generalize release metadata contract

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -105,11 +105,13 @@ jobs:
             --ignore=tests/graph/test_cozo_backend.py
             --ignore=tests/vector/test_lancedb_backend.py
           )
-          # V4.0.1 was tagged before a README-only line ceiling was identified.
+          # V4.0.1 was tagged with stale documentation and V3.7 metadata tests.
           # This one-time remediation preserves the immutable tagged package and
-          # leaves every executable, artifact, plugin, and registry gate enabled.
+          # retains executable, artifact, plugin, and registry gates.
           if [ "$RELEASE_TAG" = "v4.0.1" ]; then
             RELEASE_TEST_ARGS+=(--deselect=tests/docs/test_readme_wp13.py::test_line_count_le_720)
+            RELEASE_TEST_ARGS+=(--deselect=tests/release/test_v37_rc_candidate_contract.py::test_v37_release_source_has_final_package_version)
+            RELEASE_TEST_ARGS+=(--deselect=tests/release/test_v37_rc_candidate_contract.py::test_v37_citation_metadata_matches_the_release)
           fi
           uv run python -m pytest "${RELEASE_TEST_ARGS[@]}"
           npm test

--- a/tests/release/test_v37_rc_candidate_contract.py
+++ b/tests/release/test_v37_rc_candidate_contract.py
@@ -1,32 +1,35 @@
 # Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
 # Licensed under AGPL-3.0-or-later
-"""The current release source must carry final publishable metadata."""
+"""Release metadata must be internally consistent and publishable."""
 
 from __future__ import annotations
 
 import re
+from datetime import date
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[2]
-_FINAL_RELEASE = "4.0.0"
-_FINAL_RELEASE_DATE = "2026-08-01"
 
 
-def test_v37_release_source_has_final_package_version() -> None:
-    """Release packaging must not retain a local-version label."""
+def test_release_source_has_a_final_pep440_package_version() -> None:
+    """Release packaging must not retain a development or local-version label."""
     pyproject = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
 
     assert match is not None
-    assert match.group(1) == _FINAL_RELEASE
+    version = match.group(1)
+    assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version)
 
 
-def test_v37_citation_metadata_matches_the_release() -> None:
+def test_citation_metadata_matches_the_package_release() -> None:
+    pyproject = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    package_version = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
     citation = (_ROOT / "CITATION.cff").read_text(encoding="utf-8")
     version = re.search(r'^version:\s*"([^"]+)"', citation, re.MULTILINE)
     release_date = re.search(r'^date-released:\s*"([^"]+)"', citation, re.MULTILINE)
 
+    assert package_version is not None
     assert version is not None
     assert release_date is not None
-    assert version.group(1) == _FINAL_RELEASE
-    assert release_date.group(1) == _FINAL_RELEASE_DATE
+    assert version.group(1) == package_version.group(1)
+    assert date.fromisoformat(release_date.group(1)) <= date.today()


### PR DESCRIPTION
Replaces stale V3.7/V4.0.0 hard-coded release metadata assertions with generic final-version, CITATION parity, and non-future-date invariants. The V4.0.1 remediation workflow deselects only the obsolete tagged nodes; future tags run the generic contract.