### PR TITLE
fix(storage): disable checkpoint-on-close to eliminate WAL close-path deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to SuperLocalMemory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Storage: per-call connections in `DatabaseManager._connect()` now set
+  `SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE`, so closing a WAL-mode connection never
+  runs a checkpoint that can block indefinitely on reader marks pinned by
+  another connection. The close path holds SQLite's process-global VFS mutex,
+  and `PRAGMA busy_timeout` does not apply to it, so one stuck close could
+  convoy every later `sqlite3.connect()` in the process. Routine
+  checkpointing continues via `PRAGMA wal_autocheckpoint=400` on write paths.
+
 ## [4.0.1] - 2026-08-09 — Dashboard and operations-status correctness
 
 ### Fixed

--- a/src/superlocalmemory/storage/database.py
+++ b/src/superlocalmemory/storage/database.py
@@ -231,6 +231,18 @@ class DatabaseManager:
         conn.row_factory = sqlite3.Row
         conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
         conn.execute("PRAGMA foreign_keys=ON")
+        # Deadlock hardening (postmortem 2026-08-13, Option B): WAL close
+        # triggers a checkpoint that can wait indefinitely on reader marks
+        # pinned by another process/thread — while holding SQLite's
+        # process-global VFS mutex, which convoys every later connect().
+        # busy_timeout does NOT apply to the close path. NO_CKPT_ON_CLOSE
+        # makes close() checkpoint-free so it can never block; normal
+        # checkpointing continues via wal_autocheckpoint=400 on write paths.
+        # Available since Python 3.12 / SQLite 3.31; guarded for portability.
+        try:
+            conn.setconfig(sqlite3.SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE, 1)  # type: ignore[attr-defined]
+        except (AttributeError, sqlite3.OperationalError):
+            pass
         return conn
 
     @contextmanager

--- a/tests/test_storage/test_no_ckpt_on_close.py
+++ b/tests/test_storage/test_no_ckpt_on_close.py
@@ -1,0 +1,54 @@
+"""Regression tests for the WAL close-path deadlock fix (NO_CKPT_ON_CLOSE).
+
+Root cause (production incident + in-suite reproduction, 2026-08-13):
+closing a WAL-mode connection triggers a checkpoint inside sqlite3WalClose.
+That checkpoint can wait indefinitely on reader marks pinned by another
+connection — while the close path holds SQLite's process-global VFS mutex,
+so every later sqlite3.connect() in the process convoys behind it.
+PRAGMA busy_timeout does NOT apply to the close path.
+
+Fix: every per-call connection opened by DatabaseManager._connect() sets
+SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE, so close() never checkpoints and cannot
+block. Routine checkpointing continues via PRAGMA wal_autocheckpoint=400.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from superlocalmemory.storage.database import DatabaseManager
+
+
+def test_close_leaves_wal_uncheckpointed(tmp_path) -> None:
+    """With NO_CKPT_ON_CLOSE, close() must not checkpoint the WAL.
+
+    Observable contract: after writes through the per-call connection model,
+    the ``-wal`` sidecar still holds the frames (a checkpointing last-close
+    would merge them into the main database file and remove/truncate the
+    sidecar). This is the property that makes close() non-blocking.
+    """
+    db = tmp_path / "memory.db"
+    mgr = DatabaseManager(db)
+    mgr.execute("CREATE TABLE IF NOT EXISTS t (id INTEGER)")
+    mgr.execute("INSERT INTO t (id) VALUES (1)")
+
+    wal = tmp_path / "memory.db-wal"
+    assert wal.exists() and wal.stat().st_size > 0, (
+        "WAL sidecar missing/empty after close — conn.close() checkpointed, "
+        "which is exactly the blocking path behind the WAL close deadlock. "
+        "DatabaseManager._connect() must set SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE."
+    )
+
+
+def test_write_and_close_roundtrip(tmp_path) -> None:
+    """Durability is unaffected: written rows survive connection close."""
+    db = tmp_path / "memory.db"
+    mgr = DatabaseManager(db)
+    mgr.execute("CREATE TABLE IF NOT EXISTS t (id INTEGER)")
+    mgr.execute("INSERT INTO t (id) VALUES (42)")
+
+    probe = sqlite3.connect(str(db))
+    try:
+        assert probe.execute("SELECT id FROM t").fetchone() == (42,)
+    finally:
+        probe.close()


### PR DESCRIPTION
## Root cause

Closing a WAL-mode SQLite connection runs a checkpoint inside `sqlite3WalClose`. That checkpoint can wait indefinitely on reader marks pinned by another connection (another thread, or a long-lived second process) — and the close path holds SQLite's **process-global VFS mutex**, so every later `sqlite3.connect()` in the process queues behind it. `PRAGMA busy_timeout` does **not** apply to the close path, so the wait has no timeout.

Observed twice:

1. **Production** (2026-08-13): a host process embedding SLM had a background thread block in `conn.close()` → `sqlite3WalClose` → `unixLock` for 20+ minutes while a long-lived daemon pinned WAL reader marks. Every subsequent `sqlite3.connect()` in the process (delivery worker, cron scheduler) convoyed in `findReusableFd → pthread_mutex_lock` while the event loop and health endpoint stayed green (py-spy native stacks captured).
2. **In-tree**: the full test suite hung at `tests/test_server/test_search_fast_param_and_profile_isolation.py::test_search_profile_isolation_memory_counts` — faulthandler showed a thread blocked in `DatabaseManager._execute_one`'s `finally: conn.close()` with concurrent threads in `read_connection.snapshot` and `database.transaction`.

## Fix

Set `SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE=1` on every per-call connection in `DatabaseManager._connect()` (guarded for Python < 3.12 / SQLite < 3.31). `close()` then never checkpoints and cannot block; routine checkpointing continues via `PRAGMA wal_autocheckpoint=400` already set on write paths.

No journal-mode change, no schema change — this is the "fix close semantics" option, per https://sqlite.org/wal.html and https://sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfignockptonclose .

## Regression tests

- `test_close_leaves_wal_uncheckpointed` — behavioral: after writes through the per-call model, the `-wal` sidecar must still hold frames (a checkpointing last-close would merge and remove it). Verified to fail on unfixed code (negative control).
- `test_write_and_close_roundtrip` — durability unchanged.

## Verification

- New regression tests: 2 passed (fail without the fix).
- Previously hanging test passes in ~6.5s (was an unbounded hang).
- `tests/test_server/`: **395 passed**, zero faulthandler stalls (previously hung at ~92% under full-suite concurrency).
- Lint status of touched files identical to upstream baseline.
