### PR TITLE
docs: mcp-remote bridge install names a package that does not exist on npm

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -14,13 +14,13 @@ SLM ships with **two MCP transports**. Pick the one that fits your tool.
 |-----------|-------------|----------|-------------|
 | **HTTP** (recommended) | All clients share one daemon process | ~2 GB once, flat forever | `slm serve` must be running |
 | **stdio** (universal) | One `slm mcp` subprocess per connection | ~90–110 MB × connections | None — works offline |
-| **`mcp-remote` bridge** | stdio wrapper that tunnels to HTTP | ~50 MB bridge + HTTP pool | npm `@modelcontextprotocol/client-cli` |
+| **`mcp-remote` bridge** | stdio wrapper that tunnels to HTTP | ~50 MB bridge + HTTP pool | npm `mcp-remote` |
 
 **Quick rule:** use HTTP if your tool supports it. Use `mcp-remote` if your tool is stdio-only but you want shared RAM. Fall back to pure stdio if you are offline or running daemon-free.
 
 The `mcp-remote` bridge package:
 ```bash
-npm install -g @modelcontextprotocol/client-cli
+npm install -g mcp-remote
 ```
 
 ---
@@ -322,7 +322,7 @@ Restart Antigravity IDE after editing. The `agy` CLI picks up changes on next in
 Grok CLI supports stdio only. Use the `mcp-remote` bridge to connect via HTTP:
 
 ```bash
-npm install -g @modelcontextprotocol/client-cli
+npm install -g mcp-remote
 ```
 
 Add to `~/.grok/config.toml`:


### PR DESCRIPTION
> Disclosure: I am an AI agent (Claude), contributing with review by @tonydzi. Every command and every line of output below was run on a real machine and is reproducible.

## What was broken

`docs/ide-setup.md` tells the reader to install the `mcp-remote` bridge with:

```bash
npm install -g @modelcontextprotocol/client-cli
```

That package does not exist on npm, so the install cannot succeed:

```
$ npm install -g --prefix ./pfx @modelcontextprotocol/client-cli
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@modelcontextprotocol%2fclient-cli - Not found
```
(node 24.14.0, npm 11.9.0, isolated prefix)

Three occurrences, all in `docs/ide-setup.md`: the transport table (line 17), the bridge install block (line 23) and the Grok CLI section (line 325). Nothing else in the repo references that name. It has been there since `82484ff` (2026-06-10, "docs: document dual HTTP + stdio MCP transports (v3.6.7)") — the documented path never worked.

## Why it blocks a real user, not just a link

SLM itself writes `mcp-remote` as the command, so the reader ends up with a config pointing at a binary the documented install can never provide. Running your own connector on `a5438ee` (Python 3.12):

```python
connect_ide('cursor', home=<tmp>, transport='http-mcp-remote')
```
```json
{"superlocalmemory": {"type": "stdio", "command": "mcp-remote", "args": ["http://127.0.0.1:8765/mcp/"]}}
```

Same expectation is asserted in your tests (`tests/test_cli_subparsers/test_transport_connect.py`, C-3/C-8: `assert block["command"] == "mcp-remote"`), and `slm connect --transport http-mcp-remote` is a documented flag (`cli/main.py`).

## What it is now

The same three lines name `mcp-remote` — the package that actually ships that binary:

```
$ npm install -g --prefix ./pfx mcp-remote
added 81 packages in 2s
$ ls pfx/bin
mcp-remote -> ../lib/node_modules/mcp-remote/dist/proxy.js
mcp-remote-client -> ../lib/node_modules/mcp-remote/dist/client.js
$ pfx/bin/mcp-remote
Usage: npx tsx proxy.ts <https://server-url> [callback-port] [--debug]
```
(mcp-remote 0.1.38 — the binary name matches the `command` your connector writes.)

## Checks

`tests/test_cli_subparsers/test_transport_connect.py` on this branch: **15 passed** (Python 3.12). Identical result on unmodified `main` — the change is docs-only, 3 lines, no code touched.

If you would rather recommend `npx -y mcp-remote` (no global install) in the IDE blocks, say the word and I will send that shape instead.
