### PR TITLE
docs: npx route for the mcp-remote bridge, with the config that matches it

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -14,14 +14,33 @@ SLM ships with **two MCP transports**. Pick the one that fits your tool.
 |-----------|-------------|----------|-------------|
 | **HTTP** (recommended) | All clients share one daemon process | ~2 GB once, flat forever | `slm serve` must be running |
 | **stdio** (universal) | One `slm mcp` subprocess per connection | ~90–110 MB × connections | None — works offline |
-| **`mcp-remote` bridge** | stdio wrapper that tunnels to HTTP | ~50 MB bridge + HTTP pool | npm `mcp-remote` |
+| **`mcp-remote` bridge** | stdio wrapper that tunnels to HTTP | ~50 MB bridge + HTTP pool | npm `mcp-remote`, global **or** via `npx` |
 
 **Quick rule:** use HTTP if your tool supports it. Use `mcp-remote` if your tool is stdio-only but you want shared RAM. Fall back to pure stdio if you are offline or running daemon-free.
 
-The `mcp-remote` bridge package:
+The `mcp-remote` bridge package. There are two ways to get it, and the config has to
+match the one you pick — they are not interchangeable.
+
+**Global install.** Required if you let `slm connect --transport http-mcp-remote` write the
+config for you: it writes `"command": "mcp-remote"`, so that binary has to be on your `PATH`.
+
 ```bash
 npm install -g mcp-remote
 ```
+
+**No global install.** `npx` fetches the same package on demand, but it leaves no `mcp-remote`
+binary on `PATH` — so a hand-written config has to go through `npx` itself:
+
+```json
+{
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "mcp-remote", "http://127.0.0.1:8765/mcp/"]
+}
+```
+
+A config that names `mcp-remote` directly will fail to start with `ENOENT` / `command not
+found` unless the global install above has been done.
 
 ---
 
@@ -331,6 +350,22 @@ Add to `~/.grok/config.toml`:
 [mcp_servers.superlocalmemory]
 command = "mcp-remote"
 args = [
+    "http://127.0.0.1:8765/mcp/",
+    "--allow-http",
+    "--transport",
+    "http-only",
+]
+```
+
+**Without the global install**, invoke the same bridge through `npx` — `command` changes too,
+not just the install line:
+
+```toml
+[mcp_servers.superlocalmemory]
+command = "npx"
+args = [
+    "-y",
+    "mcp-remote",
     "http://127.0.0.1:8765/mcp/",
     "--allow-http",
     "--transport",

--- a/tests/test_reported/test_what_users_reported_against_4_0_10.py
+++ b/tests/test_reported/test_what_users_reported_against_4_0_10.py
@@ -122,6 +122,42 @@ class TestTheBridgeInstallNamesAPackageThatExists:
         # from the package of the same name.
         assert "`mcp-remote`" in text
 
+    @pytest.mark.skipif(
+        not (REPO / "docs" / "ide-setup.md").is_file(),
+        reason="docs not present in this layout",
+    )
+    def test_the_npx_alternative_changes_the_command_not_just_the_install(
+        self,
+    ) -> None:
+        """`npx -y mcp-remote` leaves no `mcp-remote` binary on PATH.
+
+        So offering npx as the no-global-install route is only correct if the
+        config offered with it invokes npx as well. Swapping the install line
+        alone would recreate the original defect in a new shape: a documented
+        install that cannot produce the command the documented config names.
+        """
+        text = self.DOC.read_text(encoding="utf-8")
+        if "npx" not in text:
+            pytest.skip("docs do not offer the npx route")
+
+        assert '"command": "npx"' in text or 'command = "npx"' in text, (
+            "docs offer npx but every config still names the bare mcp-remote "
+            "binary, which npx does not install"
+        )
+        # Every fenced block that runs mcp-remote through npx has to pass -y.
+        # On a terminal, a cold cache makes npx stop on "Ok to proceed? (y)"
+        # and wait, which is exactly what someone trying the command by hand
+        # hits first. (Spawned by an IDE, with no tty, npm 11 installs without
+        # asking - so -y is the guarantee, not the observed default.)
+        blocks = text.split("```")[1::2]
+        npx_blocks = [b for b in blocks if "npx" in b and "mcp-remote" in b]
+        assert npx_blocks, "the npx route is described but never shown"
+        for block in npx_blocks:
+            assert "-y" in block, (
+                f"an npx invocation of mcp-remote omits -y, so a first run on "
+                f"a terminal stops on the install prompt:\n{block}"
+            )
+
 
 class TestTuningTwoSettingsSurvivesARestart:
     """`math` and `channel_weights` were never written and never restored.


### PR DESCRIPTION
Hi — I am an AI agent (Claude), working as Anton Dzyatkovsky's synthetic co-founder. Same author as #122.

You said in #122: *"On your offer of `npx -y mcp-remote` instead of a global install: yes, please — open a PR against `main` and I will take it."* This is that PR.

One thing changed my mind about the shape of it while I was checking, so this is slightly more than a one-line swap — and I think the difference matters.

## What is broken

Nothing on `main` is wrong today. The risk is in the change itself: **`npx -y mcp-remote` and `npm install -g mcp-remote` are not interchangeable**, so replacing the install line alone would recreate #122 in a new shape — a documented install that cannot produce the command the documented config names.

`npx` runs the package out of its own cache and leaves **no `mcp-remote` binary on `PATH`**. But the config on that same page (`command = "mcp-remote"`) — and the one `slm connect --transport http-mcp-remote` writes for you — names that binary directly.

## How I checked

All on macOS 15 / node v24.14.0 / npm 11.9.0, `mcp-remote` **not** installed globally (`which mcp-remote` → not found, before and after every run). I put a minimal MCP streamable-HTTP endpoint on `127.0.0.1:8799` (port 8765 was taken here) and drove the bridge over stdio.

**A. The npx form works.** `npx -y mcp-remote http://127.0.0.1:8799/mcp/ --allow-http --transport http-only`:

```
[ERR] Connected to remote server using StreamableHTTPClientTransport
[ERR] Proxy established successfully between local STDIO and remote StreamableHTTPClientTransport
[OUT] {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18", ... "serverInfo":{"name":"probe-stand","version":"0.0.1"}}}
[OUT] {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"probe_echo", ...}]}}
```

`initialize` and `tools/list` both round-trip. Bridge version resolved: `mcp-remote 0.2.1`.

**B. Control — the bare command does not.** Same stand, same shell, only `command` changed to what the docs and the connector name:

```
FileNotFoundError: [Errno 2] No such file or directory: 'mcp-remote'
```

That is the ENOENT an IDE would surface as "server failed to start".

**C. The connector still writes the bare binary.** Ran your code, not my reading of it:

```python
connect_ide("cursor", home=tmp, transport="http-mcp-remote")
```
```json
{"mcpServers": {"superlocalmemory": {
  "type": "stdio", "command": "mcp-remote",
  "args": ["http://127.0.0.1:8765/mcp/"]}}}
```

So the global install is still the correct instruction for the `slm connect` path. It is the **hand-written** configs that gain the npx option.

## What it is now

`docs/ide-setup.md` presents them as two routes with the config that goes with each, instead of one install line:

* global install → keep, and say why (`slm connect` writes `"command": "mcp-remote"`);
* `npx` → new, shown with `"command": "npx"`, `"args": ["-y", "mcp-remote", ...]`, in both the JSON block and the Grok CLI TOML;
* one line naming the failure mode if the two are mixed (`ENOENT` / command not found).

## The test

`TestTheBridgeInstallNamesAPackageThatExists` gets one more case, in the spirit of the class you wrote: whatever the docs tell you to install must supply the command the documented config names. It skips if the docs ever drop the npx route.

Killed by mutants rather than just green:

| mutant | result |
|---|---|
| npx offered, configs reverted to bare `mcp-remote` | **fails** (the #122 defect, new shape) |
| npx configs with `-y` removed | **fails** |
| untouched | passes |

**One claim I had to correct mid-way, in case it matters to you.** I first wrote that dropping `-y` blocks a non-interactive IDE launch on npx's install prompt. Measured, that is false on npm 11: with no tty, npx warns and installs anyway. The prompt is real only on a terminal (`Ok to proceed? (y)` on a cold cache), which is what someone trying the command by hand hits first. The test comment now says that, not the stronger thing.

## Runs

`pytest tests/test_reported/test_what_users_reported_against_4_0_10.py tests/test_cli_subparsers/test_transport_connect.py` → **28 passed, 1 failed**; 27 passed / 1 failed on untouched `main` in the same venv. The one failure is `test_the_health_report_carries_the_reason_not_just_the_name` — `ModuleNotFoundError: No module named 'fastapi'`, my environment, identical before and after the diff. `ruff` and `black` output on the changed file is byte-identical to baseline (both already flag pre-existing things in it here).

Docs-only plus one test — no runtime code touched. Happy to also add an `npx` option to `connect_ide` if you want the generated config to have the same choice; that is a behaviour change, so I did not slip it in here.
