### PR TITLE
feat: per-request profile routing on remember/recall — daemon stays single-instance, requests carry the namespace

### DIFF
--- a/src/superlocalmemory/core/engine.py
+++ b/src/superlocalmemory/core/engine.py
@@ -543,11 +543,17 @@ class MemoryEngine:
         *,
         scope: str = "personal",
         shared_with: list[str] | None = None,
+        profile_id: str | None = None,
     ) -> list[str]:
         """Store content and extract structured facts. Returns fact_ids.
 
         Multi-scope: ``scope`` sets the visibility (personal/shared/global).
         ``shared_with`` is a list of profile_ids for shared scope.
+
+        ``profile_id`` targets a single write at any profile without
+        switching the engine's active profile (same convention as
+        ``recall``): ``None``/``""`` means the active profile, and the
+        active pointer is never mutated by the call.
         """
         self._require_full("store")
         self._ensure_init()
@@ -569,10 +575,18 @@ class MemoryEngine:
             speaker=speaker,
             role=role,
             require_complete=False,
+            profile_id=profile_id,
         )
 
-    def store_fact_direct(self, fact: AtomicFact) -> str:
-        """Durably store a pre-built fact with full enrichment."""
+    def store_fact_direct(
+        self, fact: AtomicFact, *, profile_id: str | None = None,
+    ) -> str:
+        """Durably store a pre-built fact with full enrichment.
+
+        ``profile_id`` follows the ``recall`` convention: ``None``/``""``
+        targets the active profile; an explicit value routes this one
+        write without mutating the engine's active profile.
+        """
         self._require_full("store_fact_direct")
         self._ensure_init()
 
@@ -584,6 +598,7 @@ class MemoryEngine:
             self,
             fact,
             trusted_actor_id=local_trusted_actor_id("python-api-prebuilt"),
+            profile_id=profile_id,
         )
 
     def _warm_guard_embed(
@@ -707,6 +722,7 @@ class MemoryEngine:
     def _attach_vector(
         self, fact_id: str, emb: list[float],
         fmean: float | None, fvar: float | None,
+        *, profile_id: str | None = None,
     ) -> bool:
         """Attach a vector to a stored fact. True only if a search can now find it.
 
@@ -745,11 +761,12 @@ class MemoryEngine:
         whether to finish it. Callers check their budget immediately before
         calling. Bounding the pair itself is a property of the write lock.
         """
+        pid = profile_id or self._profile_id
         projected = False
         store = getattr(self, "_vector_store", None)
         if store is not None and getattr(store, "available", False):
             try:
-                projected = bool(store.upsert(fact_id, self._profile_id, emb))
+                projected = bool(store.upsert(fact_id, pid, emb))
                 if not projected:
                     logger.warning(
                         "vector projection refused for %s — stored but not "
@@ -772,7 +789,9 @@ class MemoryEngine:
                             exc_info=True,
                         )
 
-        if not self._write_canonical_vector(fact_id, emb, fmean, fvar):
+        if not self._write_canonical_vector(
+            fact_id, emb, fmean, fvar, profile_id=pid,
+        ):
             if projected:
                 logger.warning(
                     "canonical vector write failed for %s — undoing the "
@@ -786,13 +805,14 @@ class MemoryEngine:
     def _write_canonical_vector(
         self, fact_id: str, emb: list[float],
         fmean: float | None, fvar: float | None,
+        *, profile_id: str | None = None,
     ) -> bool:
         """Write the vector to ``atomic_facts``. False if it did not land."""
         try:
             self._db.update_fact(
                 fact_id,
                 {"embedding": emb, "fisher_mean": fmean, "fisher_variance": fvar},
-                profile_id=self._profile_id,
+                profile_id=profile_id or self._profile_id,
             )
             return True
         except Exception as exc:
@@ -932,7 +952,7 @@ class MemoryEngine:
         self, content: str, metadata: dict[str, Any] | None = None,
         *, scope: str = "personal", shared_with: list[str] | None = None,
         session_date: str | None = None, speaker: str = "", role: str = "user",
-        index_external: bool = True,
+        index_external: bool = True, profile_id: str | None = None,
     ) -> list[str]:
         """v3.5.5 WRITE-THROUGH: synchronous verbatim insert for IMMEDIATE recall.
 
@@ -956,9 +976,14 @@ class MemoryEngine:
         docstring used to say "~ms, no embedding" and that had stopped being true.
 
         Returns real fact_ids immediately. Quality gate rejects template junk.
+
+        ``profile_id`` follows the ``recall`` convention: ``None``/``""``
+        targets the active profile; an explicit value routes this one
+        write without mutating the engine's active profile.
         """
         self._require_full("store_fast")
         self._ensure_init()
+        pid = profile_id or self._profile_id
         import re as _re
         import uuid as _uuid
         from datetime import datetime, timezone
@@ -986,7 +1011,7 @@ class MemoryEngine:
             pass  # gate module missing → store verbatim (never block a write)
         now = datetime.now(timezone.utc).isoformat()
         record = MemoryRecord(
-            profile_id=self._profile_id, content=content,
+            profile_id=pid, content=content,
             session_date=session_date or now[:10],
             session_id=(metadata or {}).get("session_id", ""),
             speaker=speaker,
@@ -1019,7 +1044,7 @@ class MemoryEngine:
         emb, fmean, fvar = self._warm_guard_embed(fact_text)
         fact = AtomicFact(
             fact_id=_uuid.uuid4().hex[:16], memory_id=record.memory_id,
-            profile_id=self._profile_id, content=fact_text,
+            profile_id=pid, content=fact_text,
             fact_type=FactType.EPISODIC, entities=ents,
             observation_date=session_date or now[:10],
             confidence=0.7, importance=0.5,
@@ -1036,13 +1061,13 @@ class MemoryEngine:
         # Attach the vector so the meaning-based channel finds it now, through
         # the same ordering every other write path uses.
         if emb and index_external:
-            self._attach_vector(fact.fact_id, emb, fmean, fvar)
+            self._attach_vector(fact.fact_id, emb, fmean, fvar, profile_id=pid)
         # Persist BM25 tokens too (covers the in-memory rank_bm25 fallback path).
         if index_external:
             try:
                 bm25 = getattr(self._retrieval_engine, "_bm25", None)
                 if bm25:
-                    bm25.add(fact.fact_id, fact_text, self._profile_id)
+                    bm25.add(fact.fact_id, fact_text, pid)
             except Exception:
                 pass
         return [fact.fact_id]

--- a/src/superlocalmemory/core/engine.py
+++ b/src/superlocalmemory/core/engine.py
@@ -694,7 +694,9 @@ class MemoryEngine:
             emb = None
         return emb, fmean, fvar
 
-    def _projection_has(self, fact_id: str) -> bool:
+    def _projection_has(
+        self, fact_id: str, *, profile_id: str | None = None,
+    ) -> bool:
         """Can the meaning-based channel reach this fact?
 
         Answered by the vector store, which owns the question, and never from
@@ -706,6 +708,11 @@ class MemoryEngine:
         the store; duplicating it here is how the column and the projection
         drifted apart in the first place.
 
+        ``profile_id`` follows the ``recall`` convention: ``None`` asks about
+        the active profile, an explicit value asks about THAT profile's
+        projection — per-request routed writes own facts the active pointer
+        cannot see.
+
         Fails closed. A store that cannot answer is treated as "not reachable",
         which costs at most one redundant idempotent write and can never report
         a fact as findable when it is not.
@@ -715,7 +722,7 @@ class MemoryEngine:
         if not callable(answer):
             return False
         try:
-            return bool(answer(fact_id, self._profile_id))
+            return bool(answer(fact_id, profile_id or self._profile_id))
         except Exception:
             return False
 
@@ -851,6 +858,7 @@ class MemoryEngine:
 
     def enrich_new_facts_now(
         self, fact_ids: list[str], *, timeout_s: float | None = None,
+        profile_id: str | None = None,
     ) -> int:
         """Make just-written facts searchable by meaning, within a deadline.
 
@@ -867,6 +875,13 @@ class MemoryEngine:
         closes that window for whichever facts it can reach in time, and reports
         honestly how many it reached.
 
+        ``profile_id`` follows the ``recall``/``store`` convention: ``None``
+        enriches the active profile's facts; an explicit value enriches THAT
+        profile's. The lookups below are tenant-scoped, so a routed write's
+        fact_ids resolve to ``None`` against the active profile — silently
+        skipping enrichment and always reporting "findable by wording" —
+        unless the routed profile is threaded through.
+
         The durable write has already happened before this is called. Nothing here
         can fail it: on any error or timeout the fact simply keeps its place in the
         background queue.
@@ -878,6 +893,7 @@ class MemoryEngine:
         # looks exactly like "there was nothing to enrich".
         self._require_full("enrich_new_facts_now")
         self._ensure_init()
+        pid = profile_id or self._profile_id
         # Matches the default the write path uses for its own embedding attempt;
         # the two were allowed to drift apart, so a direct caller got half the
         # budget the daemon gives.
@@ -885,10 +901,10 @@ class MemoryEngine:
         enriched = 0
         for fact_id in fact_ids:
             try:
-                fact = self._db.get_fact(fact_id, self._profile_id)
+                fact = self._db.get_fact(fact_id, pid)
                 if fact is None:
                     continue
-                already = self._projection_has(fact_id)
+                already = self._projection_has(fact_id, profile_id=pid)
                 if already and getattr(fact, "embedding", None):
                     # Findable by meaning, and the two representations agree.
                     # Counting it keeps the caller's receipt truthful: saying
@@ -937,7 +953,7 @@ class MemoryEngine:
                     # vector already on the row skips that check entirely and the
                     # fetch above can itself be slow under write contention.
                     break
-                if self._attach_vector(fact_id, emb, fmean, fvar):
+                if self._attach_vector(fact_id, emb, fmean, fvar, profile_id=pid):
                     enriched += 1
             except Exception as exc:
                 # Warning, not debug. A run that enriches nothing returns 0 in a

--- a/src/superlocalmemory/core/engine_ingestion.py
+++ b/src/superlocalmemory/core/engine_ingestion.py
@@ -288,6 +288,7 @@ def canonical_store(
     idempotency_key: str = "",
     require_complete: bool = True,
     return_receipt: bool = False,
+    profile_id: str | None = None,
 ) -> list[str] | IngestionOperation:
     """Submit canonical evidence, optionally waiting for enrichment completion.
 
@@ -296,6 +297,12 @@ def canonical_store(
     durable receipt without invoking any LLM, embedding, or graph work.  The
     daemon materializer owns that expensive, retryable enrichment.  Explicit
     complete callers retain the historical synchronous contract.
+
+    ``profile_id`` follows the ``engine.recall`` convention: ``None``/``""``
+    targets the engine's active profile; an explicit value routes this one
+    submission (journal row, queryable receipt, and every downstream
+    materialization stage, which all read the profile from the durable
+    operation record) without mutating the engine's active profile.
     """
     import time
 
@@ -334,10 +341,10 @@ def canonical_store(
             content = scrubbed
             logger.info("PII redaction: scrubbed %d identifier(s) on ingest", n_pii)
     try:
-        command = build_engine_ingestion_command(engine)
+        command = build_engine_ingestion_command(engine, profile_id=profile_id)
         receipt = command.submit(IngestionRequest(
             content=content,
-            profile_id=engine._profile_id,
+            profile_id=profile_id or engine._profile_id,
             source_type=source_type,
             idempotency_key=idempotency_key or uuid.uuid4().hex,
             metadata=dict(metadata or {}),
@@ -402,17 +409,26 @@ def canonical_store_fact(
     fact: AtomicFact,
     *,
     trusted_actor_id: str,
+    profile_id: str | None = None,
 ) -> str:
-    """Durably ingest a caller-built fact without changing its public ID."""
+    """Durably ingest a caller-built fact without changing its public ID.
+
+    ``profile_id`` follows the ``engine.recall`` convention: ``None`` or an
+    empty string targets the engine's active profile; an explicit value
+    routes this one ingestion without mutating the engine's active profile.
+    The prebuilt fact's own ``profile_id`` field is not authoritative — the
+    request's profile wins at the queryable-receipt write, exactly as for
+    any other canonical submission.
+    """
     from superlocalmemory.core.ingestion_command import IngestionRequest, IngestionState
     from superlocalmemory.core.injection import is_low_quality
 
     if is_low_quality(fact.content):
         return fact.fact_id
-    command = build_engine_ingestion_command(engine)
+    command = build_engine_ingestion_command(engine, profile_id=profile_id)
     receipt = command.submit(IngestionRequest(
         content=fact.content,
-        profile_id=engine._profile_id,
+        profile_id=profile_id or engine._profile_id,
         source_type="python-api-prebuilt",
         idempotency_key=f"prebuilt:{fact.fact_id}",
         metadata={_PREBUILT_FACT_KEY: _prebuilt_fact_payload(fact)},
@@ -433,15 +449,25 @@ def canonical_store_fact(
     return fact.fact_id
 
 
-def build_engine_ingestion_command(engine: MemoryEngine) -> IngestionCommand:
-    """Bind one initialized engine to the durable ingestion command."""
+def build_engine_ingestion_command(
+    engine: MemoryEngine, *, profile_id: str | None = None,
+) -> IngestionCommand:
+    """Bind one initialized engine to the durable ingestion command.
+
+    ``profile_id`` scopes the immediate queryable-admission writer for the
+    commands this binding produces.  ``None``/``""`` (the default, used by
+    every pre-existing caller) binds the engine's active profile.  The
+    materializer side never reads this binding: every enrichment stage
+    takes its profile from the durable ``IngestionOperation`` record, so a
+    per-request profile survives journal replay and daemon restarts.
+    """
     engine._require_full("canonical_ingestion")
     engine._ensure_init()
     repository = IngestionOperationRepository(engine._db)
     store_config = getattr(engine._config, "store", None)
     write_queryable = build_immediate_admission_handler(
         engine._db,
-        profile_id=engine._profile_id,
+        profile_id=profile_id or engine._profile_id,
         max_verbatim_chars=getattr(store_config, "max_verbatim_chars", 24_000),
         max_ingest_bytes=getattr(store_config, "max_ingest_bytes", 1_048_576),
     )

--- a/src/superlocalmemory/core/remember_runtime.py
+++ b/src/superlocalmemory/core/remember_runtime.py
@@ -228,12 +228,22 @@ class CanonicalRememberRuntime:
         journal_path: str | Path,
         materialize: Materializer | None = None,
         owner_id: str | None = None,
+        max_verbatim_chars: int = 24_000,
+        max_ingest_bytes: int = 1_048_576,
     ) -> None:
         if not profile_id:
             raise ValueError("profile_id is required")
         self._db = db
         self._profile_id = profile_id
         self._writer = writer
+        # Writer bounds retained so handlers built later for routed profiles
+        # (per-request profile routing) carry the same deterministic limits
+        # the active-profile handler was built with.
+        self._max_verbatim_chars = int(max_verbatim_chars)
+        self._max_ingest_bytes = int(max_ingest_bytes)
+        # Per-request profile routing: admission handlers bound to non-active
+        # profiles, keyed by profile_id. Built on first use, cleared on rebind.
+        self._routed_writers: dict[str, QueryableWriter] = {}
         self._materialize = materialize or _materialization_is_not_available
         self._binding_lock = threading.RLock()
         self._generation = 0
@@ -254,16 +264,24 @@ class CanonicalRememberRuntime:
 
         db = engine._db
         store_config = getattr(engine._config, "store", None)
+        max_verbatim_chars = getattr(
+            store_config, "max_verbatim_chars", 24_000,
+        )
+        max_ingest_bytes = getattr(
+            store_config, "max_ingest_bytes", 1_048_576,
+        )
         return cls(
             db=db,
             profile_id=engine._profile_id,
             writer=build_immediate_admission_handler(
                 db,
                 profile_id=engine._profile_id,
-                max_verbatim_chars=getattr(store_config, "max_verbatim_chars", 24_000),
-                max_ingest_bytes=getattr(store_config, "max_ingest_bytes", 1_048_576),
+                max_verbatim_chars=max_verbatim_chars,
+                max_ingest_bytes=max_ingest_bytes,
             ),
             journal_path=state_path("admission_journal.db"),
+            max_verbatim_chars=max_verbatim_chars,
+            max_ingest_bytes=max_ingest_bytes,
         )
 
     def start(self) -> None:
@@ -381,17 +399,28 @@ class CanonicalRememberRuntime:
         if not profile_id:
             raise CanonicalRememberUnavailable("reconfigured engine has no profile")
         store_config = getattr(getattr(engine, "_config", None), "store", None)
+        max_verbatim_chars = getattr(
+            store_config, "max_verbatim_chars", 24_000,
+        )
+        max_ingest_bytes = getattr(
+            store_config, "max_ingest_bytes", 1_048_576,
+        )
         writer = build_immediate_admission_handler(
             db,
             profile_id=profile_id,
-            max_verbatim_chars=getattr(store_config, "max_verbatim_chars", 24_000),
-            max_ingest_bytes=getattr(store_config, "max_ingest_bytes", 1_048_576),
+            max_verbatim_chars=max_verbatim_chars,
+            max_ingest_bytes=max_ingest_bytes,
         )
         with self._binding_lock:
             previous = (self._db, self._profile_id, self._writer)
             self._db = db
             self._profile_id = profile_id
             self._writer = writer
+            self._max_verbatim_chars = max_verbatim_chars
+            self._max_ingest_bytes = max_ingest_bytes
+            # Routed handlers close over the previous binding; drop them so
+            # the next routed request rebuilds against the new one.
+            self._routed_writers.clear()
             self._generation += 1
         try:
             self.replay_pending()
@@ -659,6 +688,37 @@ class CanonicalRememberRuntime:
                 "canonical mutation is temporarily unavailable"
             ) from exc
 
+    def _routed_writer_locked(self, profile_id: str) -> QueryableWriter:
+        """Return the admission handler bound to a non-active profile.
+
+        Per-request profile routing: a request carrying a different
+        profile_id must reach a handler bound to THAT profile, never a 409.
+        The handler is built once per profile and cached under the binding
+        lock. Fail-closed on a profile that does not exist, so not even a
+        journal replay can invent one.
+
+        Caller must hold ``self._binding_lock``.
+        """
+        writer = self._routed_writers.get(profile_id)
+        if writer is not None:
+            return writer
+        from superlocalmemory.core.engine_ingestion import (
+            build_immediate_admission_handler,
+        )
+
+        if not self._db.execute(
+            "SELECT 1 AS one FROM profiles WHERE profile_id = ?", (profile_id,),
+        ):
+            raise ValueError("admission command targets an unknown profile")
+        writer = build_immediate_admission_handler(
+            self._db,
+            profile_id=profile_id,
+            max_verbatim_chars=self._max_verbatim_chars,
+            max_ingest_bytes=self._max_ingest_bytes,
+        )
+        self._routed_writers[profile_id] = writer
+        return writer
+
     def _handle_admission(
         self,
         conn,
@@ -673,8 +733,13 @@ class CanonicalRememberRuntime:
         request = RememberRequest.from_payload(raw_request)
         with self._binding_lock:
             db = self._db
-            if request.profile_id != self._profile_id:
-                raise ValueError("admission command targets a different profile")
+            # Per-request profile routing: the active-profile handler serves
+            # the daemon's binding; any other existing profile gets (and
+            # caches) a handler bound to itself.
+            if request.profile_id == self._profile_id:
+                writer = self._writer
+            else:
+                writer = self._routed_writer_locked(request.profile_id)
             expected = admitted_epoch(request.profile_id, request.idempotency_key)
             if expected is not None and expected != self._generation:
                 raise ValueError("admission command epoch is stale")
@@ -698,7 +763,7 @@ class CanonicalRememberRuntime:
             with db._bind_coordinator_connection(conn, capability):
                 command_impl = IngestionCommand(
                     IngestionOperationRepository(db),
-                    write_queryable=self._writer,
+                    write_queryable=writer,
                     materialize=self._materialize,
                 )
                 try:

--- a/src/superlocalmemory/core/remember_runtime.py
+++ b/src/superlocalmemory/core/remember_runtime.py
@@ -412,7 +412,10 @@ class CanonicalRememberRuntime:
             max_ingest_bytes=max_ingest_bytes,
         )
         with self._binding_lock:
-            previous = (self._db, self._profile_id, self._writer)
+            previous = (
+                self._db, self._profile_id, self._writer,
+                self._max_verbatim_chars, self._max_ingest_bytes,
+            )
             self._db = db
             self._profile_id = profile_id
             self._writer = writer
@@ -426,7 +429,15 @@ class CanonicalRememberRuntime:
             self.replay_pending()
         except BaseException:
             with self._binding_lock:
-                self._db, self._profile_id, self._writer = previous
+                # Roll back the WHOLE binding, not just the writer triple: a
+                # stale limits pair or a routed-handler cache built against
+                # the failed binding would outlive the rebind that never
+                # happened.
+                (
+                    self._db, self._profile_id, self._writer,
+                    self._max_verbatim_chars, self._max_ingest_bytes,
+                ) = previous
+                self._routed_writers.clear()
                 self._generation -= 1
             raise
 

--- a/src/superlocalmemory/mcp/_daemon_proxy.py
+++ b/src/superlocalmemory/mcp/_daemon_proxy.py
@@ -87,6 +87,7 @@ class DaemonPoolProxy:
         known_as_of: str | None = None,
         valid_at: str | None = None,
         include_unknown: bool = False,
+        profile_id: str = "",
     ) -> dict[str, Any]:
         if self._unavailable:
             return self._unavailable_response()
@@ -95,6 +96,12 @@ class DaemonPoolProxy:
             "limit": limit,
             "session_id": session_id or "",
         }
+        # Per-request profile routing (spec section 3/5): the anchor is only
+        # serialized when the caller set it — an unset profile_id keeps the
+        # legacy query string byte-identical, exactly like the scope flags
+        # above. The daemon serves this one recall against that profile.
+        if profile_id:
+            _params["profile_id"] = profile_id
         # v3.8.2 client-driven agentic: only send ``fast`` when the caller set it
         # explicitly. Unset (None) lets the daemon resolve the configured
         # client-driven-agentic default — the same way scope flags are handled.

--- a/src/superlocalmemory/mcp/tools_core.py
+++ b/src/superlocalmemory/mcp/tools_core.py
@@ -87,6 +87,7 @@ def register_core_tools(server, get_engine: Callable) -> None:
         shared_with: str = "",
         idempotency_key: str = "",
         session_date: str = "",
+        profile_id: str = "",
     ) -> dict:
         """Store content to memory with intelligent indexing.
 
@@ -101,6 +102,12 @@ def register_core_tools(server, get_engine: Callable) -> None:
         was written. Omit it and the memory is dated today, which is what every
         memory got before 4.0.10 because there was no way to say otherwise.
         Accepts YYYY-MM-DD or a full ISO 8601 timestamp.
+
+        ``profile_id`` is an explicit namespace anchor: a non-empty value
+        routes this one write to that profile (which must already exist —
+        an unknown id is rejected, never created); empty = the active
+        profile, byte-identical to the legacy call. Routing never moves
+        the active-profile pointer.
         """
         # v3.6.10: resolve "mcp_client" sentinel → URL path (HTTP) or env var (stdio)
         if agent_id == "mcp_client":
@@ -175,13 +182,21 @@ def register_core_tools(server, get_engine: Callable) -> None:
                 # support. Retry the canonical path, then return an explicit
                 # retryable result to the MCP client.
                 for attempt in range(3):
-                    resp = await _asyncio.to_thread(daemon_request, "POST", "/remember", {
+                    body = {
                         "content": content, "tags": tags, "metadata": meta,
                         "scope": scope, "shared_with": _shared_list,
                         "session_id": session_id,
                         "session_date": session_date,
                         "idempotency_key": effective_idempotency_key or None,
-                    })
+                    }
+                    if profile_id:
+                        # Per-request profile routing (spec section 3/5): the
+                        # anchor is only put on the wire when the caller set
+                        # it, so an unset profile_id keeps the legacy request
+                        # byte-identical. The daemon routes THIS one write to
+                        # that profile without moving the active pointer.
+                        body["profile_id"] = profile_id
+                    resp = await _asyncio.to_thread(daemon_request, "POST", "/remember", body)
                     if resp and (resp.get("fact_ids") is not None or resp.get("ok")):
                         fids = resp.get("fact_ids") or []
                         materialization_state = resp.get("materialization_state")
@@ -241,6 +256,12 @@ def register_core_tools(server, get_engine: Callable) -> None:
                     or "mcp:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
                 ),
             }
+            if profile_id:
+                # DaemonPoolProxy.store forwards metadata["profile_id"] as
+                # the per-request routing anchor on POST /remember. Kept out
+                # of the metadata entirely when unset so the legacy fallback
+                # call stays byte-identical.
+                worker_meta["profile_id"] = profile_id
 
             def _store_via_daemon_pool():
                 pool = choose_pool()
@@ -314,6 +335,7 @@ def register_core_tools(server, get_engine: Callable) -> None:
         known_as_of: str | None = None,
         valid_at: str | None = None,
         include_unknown: bool = False,
+        profile_id: str = "",
     ) -> dict:
         """Search memories through hybrid retrieval, RRF fusion, and reranking.
 
@@ -351,6 +373,11 @@ def register_core_tools(server, get_engine: Callable) -> None:
         Point-in-time: optional ``as_of`` (ISO-8601 string, e.g.
         ``"2026-01-01T00:00:00+00:00"``) pins recall to a temporal snapshot;
         omit or pass ``None`` for current-state recall.
+
+        ``profile_id`` is an explicit namespace anchor: a non-empty value
+        serves this one recall against that profile (which must already
+        exist); empty = the active profile, byte-identical to the legacy
+        call. The active-profile pointer is never read or moved by it.
         """
         # v3.6.10: resolve "mcp_client" sentinel → URL path (HTTP) or env var (stdio)
         if agent_id == "mcp_client":
@@ -420,6 +447,11 @@ def register_core_tools(server, get_engine: Callable) -> None:
                     known_as_of=known_as_of,
                     valid_at=valid_at,
                     include_unknown=include_unknown,
+                    # Per-request profile routing (spec section 3/5): threaded
+                    # only when set, so an unset anchor keeps the legacy call
+                    # byte-identical and pool shapes that predate the
+                    # parameter are never asked for it.
+                    **({"profile_id": profile_id} if profile_id else {}),
                 )
 
             result = await asyncio.to_thread(

--- a/src/superlocalmemory/retrieval/entity_channel.py
+++ b/src/superlocalmemory/retrieval/entity_channel.py
@@ -18,7 +18,8 @@ import logging
 import os
 import re
 import threading
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from superlocalmemory.retrieval import spreading
@@ -54,6 +55,45 @@ def _adj_ttl_seconds() -> float:
         return max(0.0, float(os.environ.get("SLM_ENTITY_ADJ_TTL_S", "3600")))
     except (TypeError, ValueError):
         return 3600.0
+
+
+def _adj_cache_profiles() -> int:
+    """How many profile scopes the adjacency LRU keeps warm (>= 1).
+
+    The cache used to hold a single slot, so interleaved per-request profiles
+    rebuilt the whole graph (edges + entity maps + metrics + snapshot) on every
+    switch. The LRU keeps the last N (profile, include_global, include_shared)
+    scopes instead. Set SLM_ADJ_CACHE_PROFILES to tune; each slot costs roughly
+    the old single cache (~18 MB on a 232K-edge store), so the default of 3
+    bounds the worst case at ~3x that. Read at call time, same convention as
+    SLM_ENTITY_ADJ_TTL_S above, so a test or operator can retune without a
+    re-import.
+    """
+    try:
+        return max(1, int(os.environ.get("SLM_ADJ_CACHE_PROFILES", "3")))
+    except (TypeError, ValueError):
+        return 3
+
+
+@dataclass(frozen=True)
+class _AdjSlot:
+    """One cached adjacency load for one (profile, include_global, include_shared).
+
+    Groups the instance attributes that used to form the single-slot cache, so
+    the LRU can hand them back to readers exactly as a fresh load left them.
+    """
+
+    adj: dict[str, list[tuple[str, float]]]
+    entity_to_facts: dict[str, list[str]]
+    fact_to_entities: dict[str, list[str]]
+    visible_fact_ids: set[str]
+    edge_count: int
+    fact_count: int
+    loaded_at: float
+    graph_metrics: dict[str, dict]
+    graph_metrics_profile: str
+    adjacency_source_name: str
+    snapshot: Any  # graph_adjacency view; typed loosely to avoid an import cycle
 
 
 _PROPER_NOUN_RE = re.compile(r"\b[A-Z][a-z]{1,}\b")
@@ -215,6 +255,10 @@ class EntityGraphChannel:
     Replaces per-node SQLite queries (23ms each) with dict lookup (<0.001ms).
     The cache is loaded once per profile and invalidated on store/edge changes.
     Memory cost: ~18 MB for 232K edges. Zero quality change — same algorithm.
+
+    Per-request profiles: the cache holds the last SLM_ADJ_CACHE_PROFILES
+    (default 3) profile scopes in an LRU, so alternating requests do not
+    thrash a single slot into a full graph rebuild each time.
     """
 
     def __init__(
@@ -235,12 +279,18 @@ class EntityGraphChannel:
         # v3.4.5: Optional CozoDB graph backend (Sprint 2)
         self._cozo = cozo_backend
         self._cache_lock = threading.RLock()
+        # Profile-keyed LRU of adjacency loads, oldest first. Keyed by the full
+        # scope (profile, include_global, include_shared) because each scope is
+        # a different graph. The legacy single-slot attributes below always
+        # mirror the scope served by the most recent _ensure_adjacency call.
+        self._adj_slots: OrderedDict[tuple[str, bool, bool], _AdjSlot] = OrderedDict()
         # In-memory adjacency: {node_id -> [(neighbor_id, weight), ...]}
         self._adj: dict[str, list[tuple[str, float]]] = {}
         self._adj_profile: str = ""  # Track which profile is loaded
         self._adj_scope_key: tuple[str, bool, bool] | None = None
         self._adj_edge_count: int = 0  # Track edge count for staleness detection
         self._adj_fact_count: int = 0
+        self._adj_loaded_at: float = 0.0  # TTL reference for the current slot
         self._entity_to_facts: dict[str, list[str]] = defaultdict(list)
         self._fact_to_entities: dict[str, list[str]] = defaultdict(list)
         self._visible_fact_ids: set[str] = set()
@@ -257,9 +307,10 @@ class EntityGraphChannel:
     ) -> None:
         """Load graph adjacency into memory for fast spreading activation.
 
-        Loads ALL edges for a profile into a bidirectional dict.
-        Called once per profile switch or when edge count changes (new store).
-        Cost: ~1s for 232K edges, ~18 MB RAM.
+        Loads ALL edges for a profile into a bidirectional dict. Cost: ~1s for
+        232K edges, ~18 MB RAM. The last ``SLM_ADJ_CACHE_PROFILES`` scopes
+        (default 3) stay warm in an LRU, so interleaved per-request profiles do
+        not rebuild the graph on every switch.
         """
         # Check staleness: profile changed or new edges added since last load
         scope_key = (profile_id, bool(include_global), bool(include_shared))
@@ -276,25 +327,86 @@ class EntityGraphChannel:
             )
         except Exception:
             current_fact_count = -1
+        import time as _t_ec
+
+        _now_ec = _t_ec.monotonic()
         # memory-bounding-01: also reload if the cache is older than the TTL,
         # even when the edge COUNT is unchanged. Edge weights/pruning can mutate
         # the graph without changing the count (e.g. store_edge MAX-merge), and a
         # count-stable window would otherwise serve a stale adjacency map.
-        import time as _t_ec
-
-        _now_ec = _t_ec.monotonic()
-        _ttl = _adj_ttl_seconds()
         # TTL=0 disables the time-based reload entirely (count-based correctness
-        # reload still applies); otherwise the cache is fresh within the TTL.
-        _fresh = _ttl <= 0.0 or ((_now_ec - getattr(self, "_adj_loaded_at", 0.0)) < _ttl)
-        if (
-            self._adj_scope_key == scope_key
-            and (self._adj or self._visible_fact_ids)
-            and self._adj_edge_count == current_count
-            and self._adj_fact_count == current_fact_count
-            and _fresh
-        ):
-            return
+        # reload still applies); otherwise the slot is fresh within the TTL.
+        _ttl = _adj_ttl_seconds()
+        slot = self._adj_slots.get(scope_key)
+        if slot is not None:
+            _fresh = _ttl <= 0.0 or ((_now_ec - slot.loaded_at) < _ttl)
+            if (
+                (slot.adj or slot.visible_fact_ids)
+                and slot.edge_count == current_count
+                and slot.fact_count == current_fact_count
+                and _fresh
+            ):
+                self._adj_slots.move_to_end(scope_key)
+                self._restore_slot(scope_key, slot)
+                return
+        slot = self._load_adjacency_from_db(
+            profile_id,
+            include_global=include_global,
+            include_shared=include_shared,
+            current_count=current_count,
+            current_fact_count=current_fact_count,
+            now=_now_ec,
+        )
+        # Replacing an existing key keeps its old position, so the reload also
+        # counts as a use for LRU ordering.
+        self._adj_slots[scope_key] = slot
+        self._adj_slots.move_to_end(scope_key)
+        while len(self._adj_slots) > _adj_cache_profiles():
+            self._adj_slots.popitem(last=False)
+
+    def _restore_slot(
+        self,
+        scope_key: tuple[str, bool, bool],
+        slot: _AdjSlot,
+    ) -> None:
+        """Point the legacy single-slot attributes at a cached LRU slot.
+
+        Everything downstream of _ensure_adjacency (search, score_candidates,
+        _resolve_entities) reads these attributes; refreshing them per call is
+        what keeps those readers untouched by the multi-slot cache.
+        """
+        self._adj = slot.adj
+        self._adj_profile = scope_key[0]
+        self._adj_scope_key = scope_key
+        self._adj_edge_count = slot.edge_count
+        self._adj_fact_count = slot.fact_count
+        self._adj_loaded_at = slot.loaded_at
+        self._entity_to_facts = slot.entity_to_facts
+        self._fact_to_entities = slot.fact_to_entities
+        self._visible_fact_ids = slot.visible_fact_ids
+        self._graph_metrics = slot.graph_metrics
+        self._graph_metrics_profile = slot.graph_metrics_profile
+        self._adjacency_source_name = slot.adjacency_source_name
+        self._snapshot = slot.snapshot
+
+    def _load_adjacency_from_db(
+        self,
+        profile_id: str,
+        *,
+        include_global: bool = False,
+        include_shared: bool = False,
+        current_count: int = 0,
+        current_fact_count: int = -1,
+        now: float = 0.0,
+    ) -> _AdjSlot:
+        """Fetch one scope's graph from the stores and build its cache slot.
+
+        The DB-loading half of the former _ensure_adjacency; the LRU and
+        staleness bookkeeping live in the caller. Leaves the legacy instance
+        attributes describing this scope (exactly as the single-slot cache did)
+        and returns them grouped as a slot for the LRU to hold.
+        """
+        scope_key = (profile_id, bool(include_global), bool(include_shared))
         adj: dict[str, list[tuple[str, float]]] = defaultdict(list)
         # The graph projection, when there is one, answers this in 395 ms where
         # SQLite takes 2,477 ms on the same 208k-edge store (hand-measured, see
@@ -370,7 +482,7 @@ class EntityGraphChannel:
         self._adj_scope_key = scope_key
         self._adj_edge_count = current_count
         self._adj_fact_count = current_fact_count
-        self._adj_loaded_at = _now_ec  # memory-bounding-01: TTL reference
+        self._adj_loaded_at = now  # memory-bounding-01: TTL reference
         # v3.4.1: Load graph intelligence metrics (P0)
         self._load_graph_metrics(profile_id)
 
@@ -406,6 +518,19 @@ class EntityGraphChannel:
             sum(len(v) for v in self._adj.values()) // 2,
             len(self._entity_to_facts),
             profile_id,
+        )
+        return _AdjSlot(
+            adj=self._adj,
+            entity_to_facts=self._entity_to_facts,
+            fact_to_entities=self._fact_to_entities,
+            visible_fact_ids=self._visible_fact_ids,
+            edge_count=current_count,
+            fact_count=current_fact_count,
+            loaded_at=now,
+            graph_metrics=self._graph_metrics,
+            graph_metrics_profile=self._graph_metrics_profile,
+            adjacency_source_name=self._adjacency_source_name,
+            snapshot=self._snapshot,
         )
 
     def _projection_is_caught_up(self, profile_id: str) -> bool:
@@ -568,6 +693,9 @@ class EntityGraphChannel:
 
     def invalidate_cache(self) -> None:
         """Clear all caches. Call after adding/removing edges or facts."""
+        self._adj_slots.clear()
+        # The in-place clears below now operate on the evicted slots' dicts;
+        # dropping the slots above is what actually invalidates them.
         self._adj.clear()
         self._adj_profile = ""
         self._adj_scope_key = None

--- a/src/superlocalmemory/server/unified_daemon.py
+++ b/src/superlocalmemory/server/unified_daemon.py
@@ -709,6 +709,35 @@ def _require_remember_profile(requested: str, active: str) -> None:
         )
 
 
+def _daemon_profile_exists(engine, profile_id: str) -> bool:
+    """Whether ``profile_id`` names a profile row the daemon already serves."""
+    rows = engine._db.execute(
+        "SELECT 1 AS one FROM profiles WHERE profile_id = ?", (profile_id,),
+    )
+    return bool(rows)
+
+
+def _unknown_profile_body(profile_id: str) -> dict:
+    """Error body for a per-request route to a profile that does not exist.
+
+    Spec section 3/5: unknown means 404, no implicit creation, no engine call.
+    This is the daemon's existing route-local structured-error shape (same
+    pattern as the ``invalid_as_of`` 400 on /recall) — the global FastAPI
+    ``{"detail": ...}`` format is deliberately untouched.
+    """
+    return {
+        "success": False,
+        "error": {
+            "code": "unknown_profile",
+            "profile_id": profile_id,
+            "message": (
+                f"profile {profile_id!r} does not exist; per-request routing "
+                "never creates a profile implicitly"
+            ),
+        },
+    }
+
+
 class SessionOpenRequest(BaseModel):
     # #49: local session-open warm (no model roundtrip needed)
     project_path: str = ""
@@ -985,12 +1014,15 @@ def _recall_budget_s() -> float:
         return 25.0
 
 
-def _recall_keyword_fallback(engine, query: str, limit: int) -> dict:
+def _recall_keyword_fallback(
+    engine, query: str, limit: int, *, profile_id: str | None = None,
+) -> dict:
     """Fast profile-scoped keyword (LIKE) fallback for /recall.
 
     Used only when semantic recall exceeds its budget, so CLI/MCP callers get
     a bounded response instead of hanging. Mirrors the dashboard /api/search
-    fallback shape (retrieval_mode=degraded_lexical).
+    fallback shape (retrieval_mode=degraded_lexical). ``profile_id`` follows
+    the per-request routing convention: None/"" means the active profile.
     """
     results = []
     try:
@@ -998,7 +1030,7 @@ def _recall_keyword_fallback(engine, query: str, limit: int) -> dict:
             "SELECT fact_id, content, confidence FROM atomic_facts "
             "WHERE profile_id = ? AND content LIKE ? "
             "ORDER BY confidence DESC LIMIT ?",
-            (engine.profile_id, f"%{query}%", limit),
+            (profile_id or engine.profile_id, f"%{query}%", limit),
         )
         for pos, r in enumerate(rows, start=1):
             d = dict(r)
@@ -4470,6 +4502,12 @@ def _register_daemon_routes(application: FastAPI) -> None:
         request: Request,
         q: str = "", query: str = "", limit: int = CANONICAL_RECALL_LIMIT,
         session_id: str = "",
+        # Per-request profile routing (spec section 3/5): a non-empty
+        # profile_id serves this one recall against THAT profile — same
+        # existence check and same 404 envelope as POST /remember — without
+        # reading or moving the ProfileRuntime active pointer. Empty keeps
+        # the legacy active-profile path byte-identical.
+        profile_id: str = "",
         # v3.8.2 client-driven agentic: ``fast`` is left UNSET (None) by default
         # so the daemon resolves the configured policy (retrieval.client_driven_agentic,
         # ships True). The agent hot path is consumed by a frontier LLM that
@@ -4492,6 +4530,13 @@ def _register_daemon_routes(application: FastAPI) -> None:
         _update_activity()
         search_query = q or query  # Accept both ?q= and ?query= for compatibility
         engine = _get_engine_or_503()
+        req_profile = (profile_id or "").strip()
+        if req_profile and not _daemon_profile_exists(engine, req_profile):
+            from starlette.responses import JSONResponse
+
+            return JSONResponse(
+                _unknown_profile_body(req_profile), status_code=404,
+            )
         if not search_query:
             return {"results": [], "count": 0, "query_type": "none", "retrieval_time_ms": 0}
         # Phase 4b: normalize as_of at HTTP boundary. Invalid → return error.
@@ -4587,6 +4632,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
                     search_query, limit=limit, session_id=effective_sid,
                     agent_id=recall_actor,
                     fast=fast,
+                    profile_id=req_profile or None,
                     include_global=include_global,
                     include_shared=include_shared,
                     window=window or None,
@@ -4606,7 +4652,9 @@ def _register_daemon_routes(application: FastAPI) -> None:
                     "recall: semantic recall exceeded %.0fs budget for %r — "
                     "serving keyword fallback", _budget, (search_query or "")[:80],
                 )
-                return _recall_keyword_fallback(engine, search_query, limit)
+                return _recall_keyword_fallback(
+                    engine, search_query, limit, profile_id=req_profile or None,
+                )
             response = _rf.result()
             # v3.4.26: return the same field shape as recall_worker so
             # MCP processes proxying through the daemon get recall_trace-
@@ -4617,7 +4665,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
             })
             memory_map = (
                 engine._db.get_memory_content_batch(
-                    memory_ids, engine.profile_id,
+                    memory_ids, req_profile or engine.profile_id,
                     include_global=True, include_shared=True,
                 )
                 if memory_ids else {}
@@ -4687,7 +4735,26 @@ def _register_daemon_routes(application: FastAPI) -> None:
         trusted_actor_id = _require_write_actor(request)
         _update_activity()
         engine = _get_engine_or_503()
-        _require_remember_profile(req.profile_id, engine._profile_id)
+        # Per-request profile routing (spec section 3/5): a non-empty
+        # profile_id is PURE ROUTING — this one write is served against that
+        # profile while the ProfileRuntime active pointer and its generation
+        # stay untouched. Routing replaces the stale-client guard for these
+        # requests (the daemon is no longer single-profile for them); the
+        # guard keeps its legacy slot below for an empty profile_id, where it
+        # is trivially satisfied and unreachable for routed requests.
+        req_profile = (req.profile_id or "").strip()
+        if req_profile:
+            if not _daemon_profile_exists(engine, req_profile):
+                from starlette.responses import JSONResponse
+
+                return JSONResponse(
+                    _unknown_profile_body(req_profile), status_code=404,
+                )
+        else:
+            _require_remember_profile(req.profile_id, engine._profile_id)
+        # Single write-target id for everything below: the routed profile,
+        # or the engine's active profile on the legacy path. Never a 409.
+        write_profile = req_profile or engine._profile_id
 
         # v3.6.15 multi-scope: resolve the write scope. ``None`` (not specified
         # by the caller) → the configured default_scope (personal). Shared
@@ -4707,9 +4774,9 @@ def _register_daemon_routes(application: FastAPI) -> None:
             resolve_actor_roles,
         )
 
-        require_permission(request, Permission.WRITE, profile=engine._profile_id)
+        require_permission(request, Permission.WRITE, profile=write_profile)
         if scope in {"shared", "global"}:
-            require_permission(request, Permission.SHARE, profile=engine._profile_id)
+            require_permission(request, Permission.SHARE, profile=write_profile)
         runtime = getattr(application.state, "canonical_remember_runtime", None)
         if runtime is None:
             raise HTTPException(
@@ -4751,7 +4818,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
             engine._hooks.run_pre("store", {
                 "operation": "store",
                 "agent_id": trusted_actor_id,
-                "profile_id": engine._profile_id,
+                "profile_id": write_profile,
                 "content_preview": req.content[:100],
             })
 
@@ -4797,7 +4864,10 @@ def _register_daemon_routes(application: FastAPI) -> None:
 
             _http_actor = _ActorContext(
                 principal_id=trusted_actor_id,
-                roles=resolve_actor_roles(request, profile=engine._profile_id),
+                roles=resolve_actor_roles(request, profile=write_profile),
+                # The daemon's ACTIVE profile stays truthful here: per-request
+                # routing does not move it, and policy evaluates the caller
+                # against the profile it is actually serving.
                 active_profile_id=engine._profile_id,
                 transport=_Transport.HTTP,
                 client_host=_client_host,
@@ -4815,7 +4885,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
 
             admission = RememberRequest(
                 content=req.content,
-                profile_id=engine._profile_id,
+                profile_id=write_profile,
                 source_type="http",
                 idempotency_key=req.idempotency_key or uuid.uuid4().hex,
                 metadata=meta,
@@ -4827,7 +4897,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
             )
             actor = Actor(
                 principal_id=trusted_actor_id,
-                allowed_profiles=frozenset({engine._profile_id}),
+                allowed_profiles=frozenset({write_profile}),
                 allowed_scopes=frozenset({scope}),
             )
             # The whole request has a 1.5 s ceiling, and the two phases below

--- a/src/superlocalmemory/server/unified_daemon.py
+++ b/src/superlocalmemory/server/unified_daemon.py
@@ -630,9 +630,13 @@ class RememberRequest(BaseModel):
     metadata: dict | None = None  # v3.4.26: pass-through from MCP pool_store
     idempotency_key: str | None = None
     session_id: str = ""
-    # Optional compare-and-write guard for profile-sensitive clients. The
-    # daemon remains single-profile, so a stale MCP client must fail instead
-    # of silently writing into whichever profile another client selected.
+    # Per-request profile routing (spec section 3/5): a non-empty profile_id
+    # routes THIS ONE write to that profile — pure routing, the ProfileRuntime
+    # active pointer never moves, and an unknown id is a 404 (never an
+    # implicit creation). Empty/absent keeps the legacy path: the active
+    # profile. The old 409 stale-client guard remains in place only for that
+    # empty legacy shape and is unreachable for routed requests (routing
+    # replaced the guard for them).
     profile_id: str = ""
     #: WHEN this memory is about, as distinct from when it was written.
     #:
@@ -4697,7 +4701,13 @@ def _register_daemon_routes(application: FastAPI) -> None:
             profile_snapshot = get_profile_runtime(application.state).snapshot
             return {
                 "ok": True,
-                "profile": profile_snapshot.profile_id,
+                # The profile that actually served this recall: the routed
+                # profile when ?profile_id= named one, else the active one.
+                # Reporting the active profile for a routed request would
+                # tell the caller their b-profile answer came from "default".
+                # profile_generation stays from the snapshot — it describes
+                # global switch state, which per-request routing never moves.
+                "profile": req_profile or profile_snapshot.profile_id,
                 "profile_generation": profile_snapshot.generation,
                 "query": search_query,
                 "query_type": response.query_type,
@@ -4743,14 +4753,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
         # guard keeps its legacy slot below for an empty profile_id, where it
         # is trivially satisfied and unreachable for routed requests.
         req_profile = (req.profile_id or "").strip()
-        if req_profile:
-            if not _daemon_profile_exists(engine, req_profile):
-                from starlette.responses import JSONResponse
-
-                return JSONResponse(
-                    _unknown_profile_body(req_profile), status_code=404,
-                )
-        else:
+        if not req_profile:
             _require_remember_profile(req.profile_id, engine._profile_id)
         # Single write-target id for everything below: the routed profile,
         # or the engine's active profile on the legacy path. Never a 409.
@@ -4777,6 +4780,17 @@ def _register_daemon_routes(application: FastAPI) -> None:
         require_permission(request, Permission.WRITE, profile=write_profile)
         if scope in {"shared", "global"}:
             require_permission(request, Permission.SHARE, profile=write_profile)
+        # Unknown-profile rejection comes AFTER the permission gate. With
+        # existence checked first, a company-mode caller without WRITE could
+        # probe which profile ids exist: 404 for an absent one vs 403 for a
+        # present-but-forbidden one. Permission first keeps both codes intact
+        # while closing the oracle.
+        if req_profile and not _daemon_profile_exists(engine, req_profile):
+            from starlette.responses import JSONResponse
+
+            return JSONResponse(
+                _unknown_profile_body(req_profile), status_code=404,
+            )
         runtime = getattr(application.state, "canonical_remember_runtime", None)
         if runtime is None:
             raise HTTPException(
@@ -5004,6 +5018,11 @@ def _register_daemon_routes(application: FastAPI) -> None:
             searchable = "meaning" if enriched == len(fact_ids) and fact_ids else "wording"
             return {
                 "ok": True,
+                # The profile this write actually landed in: the routed
+                # profile when the request named one, else the active one.
+                # A routed caller must not be told the daemon's active
+                # profile served their write.
+                "profile": write_profile,
                 "fact_ids": fact_ids,
                 "count": len(fact_ids),
                 # Storing a memory and being able to find it again are different

--- a/src/superlocalmemory/server/unified_daemon.py
+++ b/src/superlocalmemory/server/unified_daemon.py
@@ -337,7 +337,9 @@ def _open_enrichment_pool() -> None:
         _enrichment_semaphore = threading.Semaphore(_ENRICHMENT_WORKERS)
 
 
-def _enrich_and_release(engine, fact_ids: list[str], budget: float) -> int:
+def _enrich_and_release(
+    engine, fact_ids: list[str], budget: float, profile_id: str | None = None,
+) -> int:
     """Run inline enrichment, releasing the permit only when it is really done.
 
     The permit has to be released here rather than by the caller. A caller that
@@ -345,9 +347,18 @@ def _enrich_and_release(engine, fact_ids: list[str], budget: float) -> int:
     still holding a pool thread — so releasing on the caller's timeout would let
     the next request submit into a pool that is still fully occupied, which is
     the unbounded queueing this permit exists to prevent.
+
+    ``profile_id`` is the write-target of the request these facts came from: a
+    per-request routed write names a profile the engine's active pointer does
+    not point at, and the enrichment lookups are tenant-scoped — without the
+    routed profile the facts resolve to None and every routed write reports
+    "findable by wording" no matter what. ``None`` (legacy path) enriches the
+    active profile.
     """
     try:
-        return engine.enrich_new_facts_now(fact_ids, timeout_s=budget)
+        return engine.enrich_new_facts_now(
+            fact_ids, timeout_s=budget, profile_id=profile_id,
+        )
     finally:
         _enrichment_semaphore.release()
 
@@ -4541,6 +4552,14 @@ def _register_daemon_routes(application: FastAPI) -> None:
             return JSONResponse(
                 _unknown_profile_body(req_profile), status_code=404,
             )
+        if req_profile:
+            # Same one-line-per-routed-request contract as POST /remember:
+            # the recall served a named namespace, silently as far as the
+            # active pointer is concerned.
+            logger.info(
+                "per-request profile routing: %s %s profile=%s",
+                "GET", "/recall", req_profile,
+            )
         if not search_query:
             return {"results": [], "count": 0, "query_type": "none", "retrieval_time_ms": 0}
         # Phase 4b: normalize as_of at HTTP boundary. Invalid → return error.
@@ -4791,6 +4810,16 @@ def _register_daemon_routes(application: FastAPI) -> None:
             return JSONResponse(
                 _unknown_profile_body(req_profile), status_code=404,
             )
+        if req_profile:
+            # One line per routed request, nothing on the legacy path. A
+            # daemon serving a multi-client fleet is otherwise a black box
+            # about which namespace each write actually went to — the
+            # routing is invisible in both the response envelope and the
+            # pointer, which never moves.
+            logger.info(
+                "per-request profile routing: %s %s profile=%s",
+                "POST", "/remember", req_profile,
+            )
         runtime = getattr(application.state, "canonical_remember_runtime", None)
         if runtime is None:
             raise HTTPException(
@@ -4990,6 +5019,7 @@ def _register_daemon_routes(application: FastAPI) -> None:
                         functools.partial(
                             _enrich_and_release,
                             engine, fact_ids, enrich_budget,
+                            profile_id=write_profile,
                         ),
                     )
                 except BaseException:

--- a/tests/test_core/test_canonical_ingestion_materialization.py
+++ b/tests/test_core/test_canonical_ingestion_materialization.py
@@ -1361,6 +1361,9 @@ def test_public_python_store_routes_through_canonical_ingestion_and_preserves_co
         speaker="Dana",
         role="assistant",
         require_complete=False,
+        # Per-request profile routing (spec §4): the public entry forwards
+        # its kwarg; None resolves to the engine's active profile.
+        profile_id=None,
     )
 
 

--- a/tests/test_core/test_engine_store_profile.py
+++ b/tests/test_core/test_engine_store_profile.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3 | https://qualixar.com | https://varunpratap.com
+
+"""Per-request ``profile_id`` threading on the three engine write paths.
+
+Spec §4: a caller may target any profile on a single write without
+switching the engine's active profile. Contract under test:
+
+  * ``profile_id="b"`` — the durable rows (memory, fact, ingestion
+    operation journal) land under profile ``b``;
+  * ``profile_id=None`` (and ``""``) — the engine's active profile is
+    used, byte-for-byte the pre-feature behaviour;
+  * ``engine._profile_id`` is NEVER mutated by a write call.
+
+Fixture convention: ``engine_with_mock_deps`` from ``tests/conftest.py``
+(real SQLite DB on tmp_path, real schema, mocked embedder, no LLM) —
+the same convention ``test_engine_store_path.py`` uses. Assertions are
+made against the real database rows (the actual downstream write), not
+against internal mocks.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from superlocalmemory.core.engine import MemoryEngine
+from superlocalmemory.storage.models import AtomicFact, FactType
+
+TARGET = "profile-target"
+
+
+def _seed_profile(engine: MemoryEngine, name: str = TARGET) -> None:
+    """FK on memories/atomic_facts → profiles; seed the target row.
+
+    Uses the same INSERT OR IGNORE statement schema.create_all_tables
+    uses for the 'default' profile.
+    """
+    engine._db.execute(
+        "INSERT OR IGNORE INTO profiles (profile_id, name) VALUES (?, ?)",
+        (name, name),
+    )
+
+
+def _fact_profile(engine: MemoryEngine, fact_id: str) -> str | None:
+    row = engine._db.execute(
+        "SELECT profile_id FROM atomic_facts WHERE fact_id = ?", (fact_id,),
+    )
+    return None if not row else row[0][0]
+
+
+def _memory_profile(engine: MemoryEngine, fact_id: str) -> str | None:
+    row = engine._db.execute(
+        "SELECT m.profile_id FROM memories m "
+        "JOIN atomic_facts f ON f.memory_id = m.memory_id "
+        "WHERE f.fact_id = ?",
+        (fact_id,),
+    )
+    return None if not row else row[0][0]
+
+
+def _operation_profile(engine: MemoryEngine, idempotency_key: str) -> str | None:
+    """The durable M018 journal row carries profile_id as data (spec §4.3)."""
+    row = engine._db.execute(
+        "SELECT profile_id FROM ingestion_operations WHERE idempotency_key = ?",
+        (idempotency_key,),
+    )
+    return None if not row else row[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Signature contract — Task 3/5 consume this exact shape
+# ---------------------------------------------------------------------------
+
+class TestSignatureContract:
+    @pytest.mark.parametrize(
+        "method_name", ["store", "store_fact_direct", "store_fast"],
+    )
+    def test_profile_id_is_keyword_only_last_and_defaults_none(
+        self, method_name: str,
+    ) -> None:
+        params = inspect.signature(
+            getattr(MemoryEngine, method_name),
+        ).parameters
+        assert "profile_id" in params, f"{method_name} lost profile_id"
+        param = params["profile_id"]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+        assert param.default is None
+        assert param is list(params.values())[-1], (
+            "profile_id must be appended last so existing positional "
+            "callers cannot shift"
+        )
+
+
+# ---------------------------------------------------------------------------
+# store() — canonical journal + queryable receipt path
+# ---------------------------------------------------------------------------
+
+class TestStoreProfile:
+    def test_explicit_profile_lands_in_target(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        ids = eng.store(
+            "Zed keeps a per-request profile routing test notebook",
+            session_id="s-profile", profile_id=TARGET,
+        )
+        assert ids, "store() produced no facts"
+        assert _fact_profile(eng, ids[0]) == TARGET
+        assert _memory_profile(eng, ids[0]) == TARGET
+
+    def test_explicit_profile_on_the_operation_journal(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        ids = eng.store(
+            "Yara archives the journal profile of this write",
+            profile_id=TARGET,
+        )
+        assert ids
+        # The queryable-receipt fact id is the journal's first fact id.
+        row = eng._db.execute(
+            "SELECT profile_id FROM ingestion_operations "
+            "WHERE queryable_fact_ids_json LIKE ?",
+            (f"%{ids[0]}%",),
+        )
+        assert row, "no ingestion_operations row for this store"
+        assert row[0][0] == TARGET
+
+    def test_none_falls_back_to_active(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        ids = eng.store(
+            "Uma writes without naming a profile", profile_id=None,
+        )
+        assert ids
+        assert _fact_profile(eng, ids[0]) == eng._profile_id
+
+    def test_empty_string_falls_back_to_active(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        ids = eng.store(
+            "Tomas passes an explicitly empty profile id", profile_id="",
+        )
+        assert ids
+        assert _fact_profile(eng, ids[0]) == eng._profile_id
+
+    def test_store_does_not_mutate_active_profile(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        before = eng._profile_id
+        eng.store("Sara mutates nothing by naming a profile", profile_id=TARGET)
+        assert eng._profile_id == before
+
+
+# ---------------------------------------------------------------------------
+# store_fact_direct() — prebuilt-fact canonical path
+# ---------------------------------------------------------------------------
+
+class TestStoreFactDirectProfile:
+    @staticmethod
+    def _fact(fact_id: str, content: str) -> AtomicFact:
+        fact = AtomicFact(
+            fact_id=fact_id, memory_id="", content=content,
+            fact_type=FactType.SEMANTIC, entities=["Rita"], confidence=0.9,
+        )
+        return fact
+
+    def test_explicit_profile_lands_in_target(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        fact = self._fact("direct-pid-1", "Rita routes a prebuilt fact by profile")
+        returned = eng.store_fact_direct(fact, profile_id=TARGET)
+        assert returned == "direct-pid-1"
+        assert _fact_profile(eng, "direct-pid-1") == TARGET
+        assert _memory_profile(eng, "direct-pid-1") == TARGET
+        assert _operation_profile(eng, "prebuilt:direct-pid-1") == TARGET
+
+    def test_none_falls_back_to_active(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        fact = self._fact("direct-pid-2", "Quinn omits the profile argument")
+        returned = eng.store_fact_direct(fact, profile_id=None)
+        assert returned == "direct-pid-2"
+        assert _fact_profile(eng, "direct-pid-2") == eng._profile_id
+
+    def test_does_not_mutate_active_profile(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        before = eng._profile_id
+        fact = self._fact("direct-pid-3", "Petra checks the active pointer")
+        eng.store_fact_direct(fact, profile_id=TARGET)
+        assert eng._profile_id == before
+
+
+# ---------------------------------------------------------------------------
+# store_fast() — synchronous write-through path
+# ---------------------------------------------------------------------------
+
+class TestStoreFastProfile:
+    def test_explicit_profile_lands_in_target(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        ids = eng.store_fast(
+            "Omar writes through fast into a named profile", profile_id=TARGET,
+        )
+        assert ids
+        assert _fact_profile(eng, ids[0]) == TARGET
+        assert _memory_profile(eng, ids[0]) == TARGET
+
+    def test_none_falls_back_to_active(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        ids = eng.store_fast(
+            "Nadia writes through fast with no profile", profile_id=None,
+        )
+        assert ids
+        assert _fact_profile(eng, ids[0]) == eng._profile_id
+
+    def test_does_not_mutate_active_profile(self, engine_with_mock_deps):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        before = eng._profile_id
+        eng.store_fast("Mona mutates nothing on the fast path", profile_id=TARGET)
+        assert eng._profile_id == before
+
+
+# ---------------------------------------------------------------------------
+# Isolation — a targeted write must not leak into the active profile
+# ---------------------------------------------------------------------------
+
+class TestProfileIsolation:
+    def test_targeted_write_leaves_active_profile_empty(
+        self, engine_with_mock_deps,
+    ):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        ids = eng.store(
+            "Lena is visible only to the profile she names", profile_id=TARGET,
+        )
+        assert ids
+        active_facts = eng._db.get_all_facts(eng._profile_id)
+        assert all(f.fact_id not in ids for f in active_facts), (
+            "per-request write leaked into the active profile"
+        )

--- a/tests/test_core/test_engine_store_profile.py
+++ b/tests/test_core/test_engine_store_profile.py
@@ -239,3 +239,124 @@ class TestProfileIsolation:
         assert all(f.fact_id not in ids for f in active_facts), (
             "per-request write leaked into the active profile"
         )
+
+
+# ---------------------------------------------------------------------------
+# enrich_new_facts_now / _projection_has — the inline-enrichment seam
+# (final-review I-1: routed writes must enrich against THEIR profile)
+# ---------------------------------------------------------------------------
+
+class TestEnrichmentProfileSignatureContract:
+    """profile_id is keyword-only, defaults None, appended last — the same
+    convention the three store paths above established for Tasks 3/5."""
+
+    @pytest.mark.parametrize(
+        "method_name", ["enrich_new_facts_now", "_projection_has"],
+    )
+    def test_profile_id_is_keyword_only_last_and_defaults_none(
+        self, method_name: str,
+    ) -> None:
+        params = inspect.signature(
+            getattr(MemoryEngine, method_name),
+        ).parameters
+        assert "profile_id" in params, f"{method_name} lost profile_id"
+        param = params["profile_id"]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+        assert param.default is None
+        assert param is list(params.values())[-1], (
+            "profile_id must be appended last so existing positional "
+            "callers cannot shift"
+        )
+
+
+def _warm_mock_embedder(eng, monkeypatch):
+    """Make inline enrichment actually embed under mocked deps.
+
+    The fixture's mock embedder reports itself cold-and-remote (MagicMock
+    attributes), so the warm guard declines by design. Patching the guard is
+    the sanctioned seam: the embedding itself is orthogonal to the profile
+    routing under test, and this makes an enriched>0 outcome possible so the
+    assertions are not vacuously true.
+    """
+    monkeypatch.setattr(
+        eng, "_warm_guard_embed",
+        lambda text, *, timeout_s=None: ([0.01] * 768, [0.0] * 768, [1.0] * 768),
+    )
+
+
+class TestEnrichNewFactsNowProfile:
+    def _spy_get_fact(self, eng, monkeypatch):
+        """Record every (fact_id, profile_id) lookup, then serve the real row."""
+        real = eng._db.get_fact
+        seen: list[tuple[str, object]] = []
+
+        def _spy(fact_id, profile_id=None):
+            seen.append((fact_id, profile_id))
+            return real(fact_id, profile_id)
+
+        monkeypatch.setattr(eng._db, "get_fact", _spy)
+        return seen
+
+    def test_routed_facts_resolve_against_the_routed_profile(
+        self, engine_with_mock_deps, monkeypatch,
+    ):
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        ids = eng.store(
+            "Wren logs the enrichment routing probe for the relay desk",
+            profile_id=TARGET,
+        )
+        assert ids
+        _warm_mock_embedder(eng, monkeypatch)
+        seen = self._spy_get_fact(eng, monkeypatch)
+
+        enriched = eng.enrich_new_facts_now(
+            ids, profile_id=TARGET, timeout_s=5.0,
+        )
+
+        lookups = [p for fid, p in seen if fid in ids]
+        assert lookups, "enrichment never looked up the routed facts"
+        assert set(lookups) == {TARGET}, (
+            f"routed enrichment must resolve facts against {TARGET!r}, "
+            f"got {set(lookups)!r} (active is {eng._profile_id!r})"
+        )
+        # The routed rows resolved, so enrichment ran to its honest outcome
+        # instead of skipping every fact as unfindable.
+        assert enriched == len(ids), (
+            f"expected all {len(ids)} routed fact(s) searchable by meaning, "
+            f"got {enriched}"
+        )
+
+    def test_without_the_anchor_routed_facts_are_invisible(
+        self, engine_with_mock_deps,
+    ):
+        """The lookups are tenant-scoped: this documents why the anchor must
+        be threaded. WITHOUT profile_id the routed rows resolve to None and
+        inline enrichment silently skips them — the exact pre-fix daemon
+        behaviour for every routed write."""
+        eng = engine_with_mock_deps
+        _seed_profile(eng)
+        ids = eng.store(
+            "Sable files the anchorless enrichment control note",
+            profile_id=TARGET,
+        )
+        assert ids
+        assert eng._profile_id != TARGET
+
+        assert eng.enrich_new_facts_now(ids, timeout_s=5.0) == 0
+
+    def test_legacy_facts_enrich_against_the_active_profile(
+        self, engine_with_mock_deps, monkeypatch,
+    ):
+        eng = engine_with_mock_deps
+        ids = eng.store("Orla enriches on the legacy active path")
+        assert ids
+        _warm_mock_embedder(eng, monkeypatch)
+        seen = self._spy_get_fact(eng, monkeypatch)
+
+        enriched = eng.enrich_new_facts_now(ids, timeout_s=5.0)
+
+        lookups = [p for fid, p in seen if fid in ids]
+        assert lookups
+        assert set(lookups) == {eng._profile_id}
+        assert enriched == len(ids)

--- a/tests/test_integration/test_per_request_profile_e2e.py
+++ b/tests/test_integration/test_per_request_profile_e2e.py
@@ -1,0 +1,829 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later
+
+"""End-to-end acceptance for per-request profile routing over a REAL daemon.
+
+Requirement-doc acceptance scenarios exercised here (spec section 6):
+
+1. Two clients (doris/zhihui) interleave remember/recall against a real
+   unified-daemon subprocess — each hits its own namespace, cross-invisible.
+2. ``/status`` keeps reporting the same ``profile`` and
+   ``profile_generation`` throughout — per-request routing never moves the
+   global active-pointer.
+3. Two threads, each pinned to a different ``profile_id``, concurrently
+   write N=50 memories: the database count grouped by profile is exactly
+   50/50 — zero crossover, zero orphans (total rows == 100).
+6. The MCP stdio lane: an ``mslm mcp`` child restricted to
+   ``SLM_MCP_TOOLS=remember,recall`` carries ``profile_id`` over a full
+   JSON-RPC round trip against the same daemon.
+
+Orchestration follows the established two-process pattern of
+``tests/test_integration/test_embedding_fallback_two_process.py``: a REAL
+daemon subprocess on a kernel-assigned ephemeral port with an isolated
+``SLM_DATA_DIR``. The production daemon on 8765 is never touched — the
+ephemeral port is reserved outside the public set, all child environments
+are constructed (never inherited), and teardown proves machine state was
+restored: the daemon process group is gone, its lifecycle files are
+removed, the port is bindable again, and every foreign daemon PID that was
+alive before the suite is still alive after it.
+
+The doris/zhihui profiles are pre-created as ``profiles`` table rows via
+the same raw-SQL mechanism the server tests use
+(``tests/test_server/test_per_request_profile.py``): routing must never
+implicitly create a profile.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+
+# Ports owned by public/production daemons on this machine. Never bind, never
+# connect — enforced by reserving outside this set (and the root conftest's
+# audit hook denies them in-process as a second belt).
+PRODUCTION_PORTS = {8765, 8767}
+PROFILES = ("doris", "zhihui")
+N_CONCURRENT_WRITES = 50
+
+# Unique-per-run tokens keep every marker lexical hit attributable to THIS
+# run even though one daemon serves the whole module.
+RUN_TAG = uuid.uuid4().hex[:8]
+
+_PROXY_VARS = (
+    "http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY",
+    "all_proxy", "ALL_PROXY",
+)
+_PASSTHROUGH_VARS = ("PATH", "LANG", "LC_ALL", "TMPDIR", "TERM")
+
+
+def _reserve_private_port() -> int:
+    """Ask the kernel for a loopback port, never the public daemon ports."""
+    for _ in range(20):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind(("127.0.0.1", 0))
+            port = int(listener.getsockname()[1])
+        if port not in PRODUCTION_PORTS:
+            return port
+    raise AssertionError("could not reserve an isolated daemon port")
+
+
+def _child_env(data_root: Path, port: int, home: Path, cache_root: Path) -> dict:
+    """A constructed (never inherited) environment for SLM child processes.
+
+    Everything identity-bearing is pinned inside the fixture-owned root:
+    SLM_DATA_DIR (databases, locks, descriptor), HOME, and every model cache
+    (offline so a cold cache can never trigger a network fetch). Proxy
+    variables are stripped so loopback HTTP cannot be middle-boxed.
+    """
+    env = {name: os.environ[name] for name in _PASSTHROUGH_VARS if name in os.environ}
+    env.update(
+        {
+            "HOME": str(home),
+            "PYTHONPATH": str(SRC_ROOT),
+            "SLM_DATA_DIR": str(data_root),
+            "SLM_DAEMON_PORT": str(port),
+            "OMP_NUM_THREADS": "1",
+            "KMP_DUPLICATE_LIB_OK": "TRUE",
+            "TOKENIZERS_PARALLELISM": "false",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+            "HF_HOME": str(cache_root / "huggingface"),
+            "SENTENCE_TRANSFORMERS_HOME": str(cache_root / "sentence-transformers"),
+            "XDG_CACHE_HOME": str(cache_root),
+            "CI": "1",
+            "SLM_NON_INTERACTIVE": "1",
+            "SLM_TEST_ISOLATION": "1",
+            "NO_PROXY": "127.0.0.1,localhost",
+            "no_proxy": "127.0.0.1,localhost",
+        }
+    )
+    for var in _PROXY_VARS:
+        env.pop(var, None)
+    return env
+
+
+def _foreign_daemon_pids() -> set[int]:
+    """PIDs of unified daemons that do not belong to this test (production)."""
+    try:
+        import psutil
+    except Exception:  # pragma: no cover — psutil is a test dependency
+        return set()
+    mine = os.getpid()
+    pids: set[int] = set()
+    for proc in psutil.process_iter(["pid", "cmdline"]):
+        try:
+            cmdline = " ".join(proc.info["cmdline"] or [])
+        except Exception:
+            continue
+        if (
+            proc.info["pid"] != mine
+            and "superlocalmemory.server.unified_daemon" in cmdline
+        ):
+            pids.add(proc.info["pid"])
+    return pids
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+class _RpcClient:
+    """Newline-delimited JSON-RPC driver for one ``mslm mcp`` stdio child."""
+
+    def __init__(self, proc: subprocess.Popen, stderr_path: Path) -> None:
+        self._proc = proc
+        self._stderr_path = stderr_path
+        self._responses: dict[object, dict] = {}
+        self._next_id = 0
+        self._reader = threading.Thread(target=self._read_forever, daemon=True)
+        self._reader.start()
+
+    def _read_forever(self) -> None:
+        try:
+            for raw in self._proc.stdout:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line:
+                    continue
+                try:
+                    message = json.loads(line)
+                except ValueError:
+                    continue
+                if "id" in message:
+                    self._responses[message["id"]] = message
+        except Exception:  # reader must outlive the child silently
+            pass
+
+    def _stderr_tail(self) -> str:
+        try:
+            return self._stderr_path.read_text(
+                encoding="utf-8", errors="replace",
+            )[-1500:]
+        except OSError:
+            return "(stderr log unavailable)"
+
+    def call(self, method: str, params: dict | None = None, *, timeout: float = 120.0) -> dict:
+        self._next_id += 1
+        request_id = self._next_id
+        payload = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        self._proc.stdin.flush()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if request_id in self._responses:
+                return self._responses[request_id]
+            if self._proc.poll() is not None:
+                raise AssertionError(
+                    f"mcp child exited rc={self._proc.returncode} during {method}; "
+                    f"stderr tail:\n{self._stderr_tail()}"
+                )
+            time.sleep(0.05)
+        raise AssertionError(
+            f"timed out waiting for {method} response; stderr tail:\n"
+            f"{self._stderr_tail()}"
+        )
+
+    def notify(self, method: str) -> None:
+        payload = {"jsonrpc": "2.0", "method": method}
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        self._proc.stdin.flush()
+
+    def close(self) -> None:
+        """Close stdin (FastMCP exits on EOF), then escalate if needed."""
+        try:
+            self._proc.stdin.close()
+        except OSError:
+            pass
+        try:
+            self._proc.wait(timeout=15)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        self._proc.terminate()
+        try:
+            self._proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait(timeout=10)
+
+
+class RealDaemon:
+    """One real unified-daemon subprocess in a fixture-owned namespace."""
+
+    def __init__(self, proc: subprocess.Popen, port: int, data_root: Path,
+                 stdout_log: Path, env: dict) -> None:
+        self.proc = proc
+        self.port = port
+        self.data_root = data_root
+        self.stdout_log = stdout_log
+        self.env = env
+
+    # -- identity ---------------------------------------------------------
+
+    @property
+    def descriptor_path(self) -> Path:
+        return self.data_root / "daemon.json"
+
+    def descriptor(self) -> dict:
+        return json.loads(self.descriptor_path.read_text(encoding="utf-8"))
+
+    # -- HTTP -------------------------------------------------------------
+
+    def request(self, method: str, path: str, body: dict | None = None,
+                params: dict | None = None, timeout: float = 90.0) -> tuple[int, dict]:
+        """Authenticated loopback request using the daemon's own capability.
+
+        Mirrors ``superlocalmemory.cli.daemon.daemon_request``: the
+        descriptor in OUR data root carries the capability/instance headers
+        the write routes require.
+        """
+        descriptor = self.descriptor()
+        url = f"http://127.0.0.1:{self.port}{path}"
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        headers = {"Content-Type": "application/json"} if data else {}
+        headers["X-SLM-Daemon-Capability"] = descriptor["capability"]
+        headers["X-SLM-Target-Instance"] = descriptor["instance_id"]
+        request = urllib.request.Request(
+            url, data=data, headers=headers, method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return response.status, json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            payload = exc.read().decode("utf-8", "replace")
+            try:
+                return exc.code, json.loads(payload)
+            except ValueError:
+                return exc.code, {"raw": payload}
+
+    def status(self) -> dict:
+        code, payload = self.request("GET", "/status")
+        assert code == 200, payload
+        return payload
+
+    def remember(self, content: str, profile_id: str, idempotency_key: str) -> dict:
+        body = {"content": content, "idempotency_key": idempotency_key}
+        if profile_id:
+            body["profile_id"] = profile_id
+        code, payload = self.request("POST", "/remember", body)
+        assert code == 200, payload
+        assert payload.get("ok") is True, payload
+        return payload
+
+    def recall(self, query: str, profile_id: str) -> dict:
+        code, payload = self.request(
+            "GET", "/recall", params={"q": query, "profile_id": profile_id},
+        )
+        assert code == 200, payload
+        return payload
+
+    # -- lifecycle --------------------------------------------------------
+
+    def _log_tail(self) -> str:
+        chunks = []
+        for path in (self.stdout_log, self.data_root / "logs" / "daemon.log"):
+            try:
+                chunks.append(
+                    f"--- {path} ---\n"
+                    + path.read_text(encoding="utf-8", errors="replace")[-2500:]
+                )
+            except OSError:
+                continue
+        return "\n".join(chunks) or "(no daemon logs available)"
+
+    def wait_ready(self, timeout: float = 300.0) -> None:
+        """Wait until /status answers 200 (engine serving requests).
+
+        /health is deliberately NOT the readiness bar here: it embeds a
+        channel-health probe that can trail engine readiness by minutes on a
+        cold, offline-model sandbox. /status is the daemon's own
+        non-blocking "serving" answer.
+        """
+        deadline = time.monotonic() + timeout
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise AssertionError(
+                    f"daemon exited rc={self.proc.returncode} during startup;\n"
+                    f"{self._log_tail()}"
+                )
+            try:
+                code, _ = self.request("GET", "/status", timeout=5)
+                if code == 200:
+                    return
+            except Exception as exc:  # not listening yet / descriptor missing
+                last_error = exc
+            time.sleep(0.5)
+        raise AssertionError(
+            f"daemon not ready within {timeout}s (last error: {last_error!r});\n"
+            f"{self._log_tail()}"
+        )
+
+    def wait_health_fast(self, timeout: float = 300.0) -> None:
+        """Wait until /health answers 200 within daemon_request's 2s bar.
+
+        The MCP tool lane preflights /health with a 2-second timeout before
+        every daemon call; only a fast answer proves the child will route
+        through this daemon instead of reporting DAEMON_UNAVAILABLE.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{self.port}/health", timeout=2,
+                ) as response:
+                    if response.status == 200:
+                        return
+            except Exception:
+                pass
+            time.sleep(2.0)
+        raise AssertionError(
+            "/health never answered within the 2s daemon_request preflight "
+            f"bar after {timeout}s;\n" + self._log_tail()
+        )
+
+    def precreate_profiles(self, profiles: tuple[str, ...]) -> None:
+        """Insert profiles table rows the way the server tests do.
+
+        A routed write must find its profile already present (routing never
+        implicitly creates one), so doris/zhihui are seeded by hand before
+        any client talks to the daemon. WAL + busy_timeout lets this short
+        write land while the daemon holds the database.
+        """
+        conn = sqlite3.connect(self.data_root / "memory.db", timeout=30)
+        try:
+            conn.execute("PRAGMA busy_timeout=30000")
+            for profile_id in profiles:
+                conn.execute(
+                    "INSERT OR IGNORE INTO profiles (profile_id, name) "
+                    "VALUES (?, ?)",
+                    (profile_id, f"E2E Profile {profile_id}"),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+        # Prove the daemon sees the rows: a routed recall of a seeded
+        # profile must be a normal 200, not the unknown_profile 404.
+        for profile_id in profiles:
+            code, payload = self.request(
+                "GET", "/recall",
+                params={"q": "seeded-profile-probe", "profile_id": profile_id},
+            )
+            assert code == 200, payload
+
+    def fact_rows(self, where: str, args: tuple) -> list[tuple]:
+        conn = sqlite3.connect(self.data_root / "memory.db", timeout=30)
+        try:
+            conn.execute("PRAGMA busy_timeout=30000")
+            return conn.execute(
+                f"SELECT profile_id, COUNT(*) FROM atomic_facts "
+                f"WHERE {where} GROUP BY profile_id",
+                args,
+            ).fetchall()
+        finally:
+            conn.close()
+
+    def _group_members(self) -> list[str]:
+        """Live processes still in the daemon's process group."""
+        listing = subprocess.run(
+            ["ps", "-eo", "pid,pgid,args"],
+            capture_output=True, text=True, timeout=30,
+        ).stdout.splitlines()
+        return [
+            line for line in listing
+            if line.split() and line.split()[1] == str(self.proc.pid)
+        ]
+
+    def stop(self, foreign_before: set[int]) -> None:
+        """Stop the daemon and PROVE machine state was restored."""
+        # 1. Graceful stop via the daemon's own capability-bound route.
+        try:
+            self.request("POST", "/stop", body={}, timeout=10)
+        except Exception:
+            pass  # escalate below
+        graceful = True
+        try:
+            self.proc.wait(timeout=90)
+        except subprocess.TimeoutExpired:
+            graceful = False
+            if os.name == "posix":
+                os.killpg(self.proc.pid, signal.SIGTERM)
+            else:
+                self.proc.terminate()
+            try:
+                self.proc.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                if os.name == "posix":
+                    os.killpg(self.proc.pid, signal.SIGKILL)
+                else:
+                    self.proc.kill()
+                self.proc.wait(timeout=20)
+        # 2. No member of the daemon's process group survives (workers
+        #    included — they were spawned into the same session). Workers
+        #    self-terminate on a ~10s parent-watchdog poll after the daemon
+        #    exits, so grant that grace, then force, then assert.
+        if os.name == "posix":
+            deadline = time.monotonic() + 30
+            leaked = self._group_members()
+            while leaked and time.monotonic() < deadline:
+                time.sleep(1.0)
+                leaked = self._group_members()
+            if leaked:
+                try:
+                    os.killpg(self.proc.pid, signal.SIGTERM)
+                except OSError:
+                    pass
+                time.sleep(2.0)
+                leaked = self._group_members()
+            assert leaked == [], (
+                f"daemon process group {self.proc.pid} leaked members: {leaked}"
+            )
+
+        # 3. Graceful stop removes exactly the ephemeral lifecycle identity.
+        if graceful:
+            for name in ("daemon.json", "daemon.pid", "daemon.port"):
+                assert not (self.data_root / name).exists(), (
+                    f"stale lifecycle state survived stop: {name}"
+                )
+
+        # 4. The ephemeral port is bindable again.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            probe.bind(("127.0.0.1", self.port))
+
+        # 5. The production daemon was never touched: every foreign daemon
+        #    PID observed before this suite is still alive.
+        still_alive = {pid for pid in foreign_before if _alive(pid)}
+        assert still_alive == foreign_before, (
+            f"foreign daemons changed during the suite: "
+            f"before={sorted(foreign_before)} after={sorted(still_alive)}"
+        )
+
+
+@pytest.fixture(scope="module")
+def real_daemon(tmp_path_factory):
+    """The REAL daemon subprocess shared by every acceptance scenario below."""
+    root = tmp_path_factory.mktemp("prp-e2e")
+    data_root = root / "data"
+    data_root.mkdir()
+    port = _reserve_private_port()
+    assert port not in PRODUCTION_PORTS
+    env = _child_env(data_root, port, root / "home", root / "cache")
+
+    foreign_before = _foreign_daemon_pids()
+
+    stdout_log = root / "daemon-stdout.log"
+    with stdout_log.open("wb") as log_file:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "superlocalmemory.server.unified_daemon",
+             "--start", f"--port={port}"],
+            stdout=log_file, stderr=log_file, env=env, cwd=str(REPO_ROOT),
+            start_new_session=os.name == "posix",
+        )
+    daemon = RealDaemon(proc, port, data_root, stdout_log, env)
+    try:
+        daemon.wait_ready()
+        daemon.precreate_profiles(PROFILES)
+        yield daemon
+    finally:
+        daemon.stop(foreign_before)
+
+
+def _contents(payload: dict) -> list[str]:
+    return [str(item.get("content", "")) for item in payload.get("results", [])]
+
+
+class TestAcceptance1InterleavedTwoClients:
+    """Scenario 1: two clients, interleaved, each hits only its namespace."""
+
+    def test_interleaved_remember_recall_is_cross_invisible(self, real_daemon):
+        doris_token = f"PrpE2e{RUN_TAG}DorisReef"
+        zhihui_token = f"PrpE2e{RUN_TAG}ZhihuiLark"
+        status_snapshots = [real_daemon.status()]
+
+        # Interleaved writes: doris, zhihui, doris, zhihui — the ordering
+        # that silently re-routed clients under the global pointer before.
+        real_daemon.remember(
+            f"{doris_token} maintains the harbor pilot rota and files the "
+            "tide-window ledger for the northern approach.",
+            profile_id="doris", idempotency_key=f"{RUN_TAG}-inter-d1",
+        )
+        status_snapshots.append(real_daemon.status())
+        real_daemon.remember(
+            f"{zhihui_token} tunes the lantern festival drones and keeps the "
+            "flight permits for the river parade.",
+            profile_id="zhihui", idempotency_key=f"{RUN_TAG}-inter-z1",
+        )
+        status_snapshots.append(real_daemon.status())
+        real_daemon.remember(
+            f"{doris_token} also audits the breaklight buoys every spring tide.",
+            profile_id="doris", idempotency_key=f"{RUN_TAG}-inter-d2",
+        )
+        status_snapshots.append(real_daemon.status())
+        real_daemon.remember(
+            f"{zhihui_token} rehearses the drone swarm over the old mint.",
+            profile_id="zhihui", idempotency_key=f"{RUN_TAG}-inter-z2",
+        )
+        status_snapshots.append(real_daemon.status())
+
+        # Each client's recall hits its own namespace.
+        doris_hits = _contents(real_daemon.recall(
+            f"{doris_token} harbor pilot rota", profile_id="doris",
+        ))
+        assert doris_hits, "doris recall must hit the doris namespace"
+        assert any(doris_token in content for content in doris_hits)
+        assert not any(zhihui_token in content for content in doris_hits), (
+            "zhihui memory leaked into the doris namespace"
+        )
+
+        zhihui_hits = _contents(real_daemon.recall(
+            f"{zhihui_token} drone flight permits", profile_id="zhihui",
+        ))
+        assert zhihui_hits, "zhihui recall must hit the zhihui namespace"
+        assert any(zhihui_token in content for content in zhihui_hits)
+        assert not any(doris_token in content for content in zhihui_hits), (
+            "doris memory leaked into the zhihui namespace"
+        )
+
+        # Cross-visibility: the other client's unique token is invisible.
+        # (Token absence, not an empty result list: by the time later
+        # scenarios share this daemon, a zhihui-routed recall may legitimately
+        # surface zhihui's own facts — a doris token there is the leak.)
+        doris_via_zhihui = _contents(real_daemon.recall(
+            f"{doris_token} harbor pilot rota", profile_id="zhihui",
+        ))
+        assert not any(doris_token in c for c in doris_via_zhihui), (
+            "doris facts must be invisible to a zhihui-routed recall"
+        )
+        zhihui_via_doris = _contents(real_daemon.recall(
+            f"{zhihui_token} drone flight permits", profile_id="doris",
+        ))
+        assert not any(zhihui_token in c for c in zhihui_via_doris), (
+            "zhihui facts must be invisible to a doris-routed recall"
+        )
+
+        # The routed writes never landed anywhere else.
+        rows = real_daemon.fact_rows(
+            "content LIKE ? OR content LIKE ?",
+            (f"%{doris_token}%", f"%{zhihui_token}%"),
+        )
+        assert dict(rows) == {"doris": 2, "zhihui": 2}, rows
+
+
+class TestAcceptance2GlobalPointerFrozen:
+    """Scenario 2: profile + profile_generation never move while routing."""
+
+    def test_status_pointer_and_generation_unchanged_throughout(self, real_daemon):
+        before = real_daemon.status()
+        active = before["profile"]
+        assert active not in PROFILES, (
+            "the fresh daemon's active profile must differ from the routed "
+            "ones, or the freeze assertions below would pass vacuously"
+        )
+
+        snapshots = [before]
+        real_daemon.remember(
+            f"PrpE2e{RUN_TAG}QuartzDune buffers the quarterly readiness "
+            "review for the on-call rotation.",
+            profile_id="doris", idempotency_key=f"{RUN_TAG}-freeze-d1",
+        )
+        snapshots.append(real_daemon.status())
+        real_daemon.remember(
+            f"PrpE2e{RUN_TAG}QuartzDune archives the ferry manifest archive.",
+            profile_id="zhihui", idempotency_key=f"{RUN_TAG}-freeze-z1",
+        )
+        snapshots.append(real_daemon.status())
+        assert real_daemon.recall(
+            f"PrpE2e{RUN_TAG}QuartzDune readiness review", profile_id="doris",
+        )["results"], "routed recall must succeed for the freeze scenario"
+        snapshots.append(real_daemon.status())
+        assert real_daemon.recall(
+            f"PrpE2e{RUN_TAG}QuartzDune ferry manifest", profile_id="zhihui",
+        )["results"], "routed recall must succeed for the freeze scenario"
+        snapshots.append(real_daemon.status())
+
+        for index, snapshot in enumerate(snapshots):
+            assert snapshot["profile"] == active, (
+                f"active pointer moved at snapshot {index}: "
+                f"{active!r} -> {snapshot['profile']!r}"
+            )
+            assert snapshot["profile_generation"] == before["profile_generation"], (
+                f"profile_generation moved at snapshot {index}: "
+                f"{before['profile_generation']!r} -> "
+                f"{snapshot['profile_generation']!r}"
+            )
+
+
+class TestAcceptance3ConcurrentWriters:
+    """Scenario 3: two threads, two profiles, N=50 each — count, no crossover."""
+
+    def test_concurrent_writes_group_count_50_50_zero_crossover(self, real_daemon):
+        doris_marker = f"PrpE2e{RUN_TAG}ConcDoris"
+        zhihui_marker = f"PrpE2e{RUN_TAG}ConcZhihui"
+        before = real_daemon.status()
+        failures: list[str] = []
+        barrier = threading.Barrier(2)
+
+        def writer(profile_id: str, marker: str) -> None:
+            barrier.wait()  # maximize true interleaving of the two writers
+            for index in range(N_CONCURRENT_WRITES):
+                try:
+                    payload = real_daemon.remember(
+                        f"{marker} shard {index:02d} journals the "
+                        f"{'harbor' if profile_id == 'doris' else 'lantern'} "
+                        f"rotation duty {RUN_TAG}-{index:02d}.",
+                        profile_id=profile_id,
+                        idempotency_key=f"{RUN_TAG}-conc-{profile_id}-{index:02d}",
+                    )
+                    if payload.get("profile") != profile_id:
+                        failures.append(
+                            f"{profile_id}[{index}] echoed profile "
+                            f"{payload.get('profile')!r}"
+                        )
+                except AssertionError as exc:
+                    failures.append(f"{profile_id}[{index}]: {exc}")
+
+        threads = [
+            threading.Thread(target=writer, args=("doris", doris_marker)),
+            threading.Thread(target=writer, args=("zhihui", zhihui_marker)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=600)
+        assert not any(thread.is_alive() for thread in threads), (
+            "a concurrent writer thread did not finish"
+        )
+        assert failures == [], f"{len(failures)} writes failed: {failures[:5]}"
+
+        # Grouped count: exactly 50/50 for the two markers.
+        rows = real_daemon.fact_rows(
+            "content LIKE ? OR content LIKE ?",
+            (f"%{doris_marker}%", f"%{zhihui_marker}%"),
+        )
+        assert dict(rows) == {
+            "doris": N_CONCURRENT_WRITES, "zhihui": N_CONCURRENT_WRITES,
+        }, f"concurrent writes miscounted: {rows}"
+
+        # Zero crossover: no row for one marker sits in the other profile
+        # (or anywhere else), and zero orphans: total rows == 100.
+        crossover, total = 0, 0
+        conn = sqlite3.connect(real_daemon.data_root / "memory.db", timeout=30)
+        try:
+            conn.execute("PRAGMA busy_timeout=30000")
+            for marker, owner in (
+                (doris_marker, "doris"), (zhihui_marker, "zhihui"),
+            ):
+                crossover += conn.execute(
+                    "SELECT COUNT(*) FROM atomic_facts "
+                    "WHERE content LIKE ? AND profile_id != ?",
+                    (f"%{marker}%", owner),
+                ).fetchone()[0]
+                total += conn.execute(
+                    "SELECT COUNT(*) FROM atomic_facts WHERE content LIKE ?",
+                    (f"%{marker}%",),
+                ).fetchone()[0]
+        finally:
+            conn.close()
+        assert crossover == 0, f"{crossover} rows crossed profile boundaries"
+        assert total == 2 * N_CONCURRENT_WRITES, (
+            f"expected {2 * N_CONCURRENT_WRITES} rows, found {total} "
+            "(missing rows = lost writes, extra = orphans)"
+        )
+
+        after = real_daemon.status()
+        assert after["profile"] == before["profile"]
+        assert after["profile_generation"] == before["profile_generation"]
+
+
+class TestAcceptance6McpStdioLane:
+    """Scenario 6: profile_id survives a full MCP stdio JSON-RPC round trip."""
+
+    def test_mcp_stdio_remember_recall_carries_profile_id(self, real_daemon):
+        # daemon_request preflights /health with a 2s timeout; only a fast
+        # answer lets the child route through THIS daemon (a slow one makes
+        # the tool return DAEMON_UNAVAILABLE instead of silently falling
+        # back, so success below proves daemon routing).
+        real_daemon.wait_health_fast()
+
+        token = f"PrpE2e{RUN_TAG}McpSable"
+        env = dict(real_daemon.env)
+        env.update(
+            {
+                "SLM_MCP_TOOLS": "remember,recall",
+                # Skip the ensure_daemon warmup thread: the descriptor in
+                # our isolated root already names the test daemon, and the
+                # test must never auto-start anything else.
+                "SLM_DISABLE_WARMUP_SIDE_EFFECTS": "1",
+            }
+        )
+        stderr_path = real_daemon.data_root.parent / "mcp-stderr.log"
+        with stderr_path.open("wb") as stderr_log:
+            mcp = subprocess.Popen(
+                [sys.executable, "-m", "superlocalmemory.cli.main", "mcp"],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=stderr_log, env=env, cwd=str(REPO_ROOT),
+            )
+        client = _RpcClient(mcp, stderr_path)
+        try:
+            # Full handshake a real IDE performs over stdio.
+            initialized = client.call("initialize", {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "prp-e2e", "version": "1.0"},
+            })
+            assert "result" in initialized, initialized
+            client.notify("notifications/initialized")
+
+            # R5 allowlist: SLM_MCP_TOOLS=remember,recall exposes exactly
+            # the minimal routed pair and nothing else.
+            listed = client.call("tools/list", {})
+            tool_names = {tool["name"] for tool in listed["result"]["tools"]}
+            assert tool_names == {"remember", "recall"}, tool_names
+
+            status_before = real_daemon.status()
+
+            def tool_payload(result: dict) -> dict:
+                assert result.get("result", {}).get("isError") is not True, result
+                return json.loads(result["result"]["content"][0]["text"])
+
+            remembered = tool_payload(client.call("tools/call", {
+                "name": "remember",
+                "arguments": {
+                    "content": (
+                        f"{token} charts the ferry wake schedule across the "
+                        "strait for the night crew."
+                    ),
+                    "profile_id": "doris",
+                    "idempotency_key": f"{RUN_TAG}-mcp-doris-1",
+                },
+            }))
+            assert remembered["success"] is True, remembered
+            assert remembered.get("fact_ids"), remembered
+
+            # The write landed in doris — and nowhere else.
+            rows = real_daemon.fact_rows(
+                "content LIKE ?", (f"%{token}%",),
+            )
+            assert dict(rows) == {"doris": 1}, rows
+
+            recalled = tool_payload(client.call("tools/call", {
+                "name": "recall",
+                "arguments": {
+                    "query": f"{token} ferry wake schedule",
+                    "profile_id": "doris",
+                },
+            }))
+            assert recalled["success"] is True, recalled
+            assert any(
+                token in str(item.get("content", ""))
+                for item in recalled.get("results", [])
+            ), f"mcp recall must hit the doris namespace: {recalled}"
+
+            # Cross-invisibility through the same lane: no doris-token fact
+            # may surface from a zhihui-routed recall.
+            cross = tool_payload(client.call("tools/call", {
+                "name": "recall",
+                "arguments": {
+                    "query": f"{token} ferry wake schedule",
+                    "profile_id": "zhihui",
+                },
+            }))
+            assert not any(
+                token in str(item.get("content", ""))
+                for item in cross.get("results", [])
+            ), f"mcp recall leaked doris facts into zhihui: {cross}"
+
+            # The global pointer survived the whole stdio session.
+            status_after = real_daemon.status()
+            assert status_after["profile"] == status_before["profile"]
+            assert (
+                status_after["profile_generation"]
+                == status_before["profile_generation"]
+            )
+        finally:
+            client.close()
+            assert mcp.poll() is not None, "mcp child must exit after stdin EOF"

--- a/tests/test_retrieval/test_adjacency_profile_lru.py
+++ b/tests/test_retrieval/test_adjacency_profile_lru.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later - see LICENSE file
+# Part of SuperLocalMemory V3
+
+"""Adjacency cache: profile-keyed LRU replaces single-slot reload thrash.
+
+The single-slot cache reloaded the whole graph (edges + entity maps +
+metrics + snapshot) on every profile switch, so interleaved per-request
+profiles paid a full rebuild per request. The LRU keeps the last
+``SLM_ADJ_CACHE_PROFILES`` scopes warm instead.
+
+Fixture convention: real SQLite ``DatabaseManager`` + ``schema.create_all_tables``
+via ``raw_connection`` (as in ``test_remaining_scope_contract.scoped_db``);
+``EntityGraphChannel`` needs no embedder. Each profile owns one visible fact
+so the staleness check's ``(_adj or _visible_fact_ids)`` guard sees a
+non-empty corpus and a hot hit is possible at all.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from superlocalmemory.retrieval.entity_channel import EntityGraphChannel
+from superlocalmemory.storage import schema
+from superlocalmemory.storage.database import DatabaseManager
+
+PROFILES = ("a", "b", "c")
+
+
+def _channel(tmp_path) -> EntityGraphChannel:
+    db = DatabaseManager(tmp_path / "adj_lru.db")
+    with db.raw_connection() as conn:
+        schema.create_all_tables(conn)
+        for profile_id in PROFILES:
+            fact_id = f"fact_{profile_id}"
+            conn.execute(
+                "INSERT OR IGNORE INTO profiles (profile_id, name) VALUES (?, ?)",
+                (profile_id, profile_id),
+            )
+            conn.execute(
+                "INSERT INTO memories "
+                "(memory_id, profile_id, scope, shared_with, content) "
+                "VALUES (?, ?, 'personal', NULL, ?)",
+                (f"m_{profile_id}", profile_id, fact_id),
+            )
+            conn.execute(
+                "INSERT INTO atomic_facts "
+                "(fact_id, memory_id, profile_id, scope, shared_with, content, "
+                " fact_type, confidence, importance, evidence_count, access_count, "
+                " canonical_entities_json, embedding, created_at) "
+                "VALUES (?, ?, ?, 'personal', NULL, ?, 'semantic', 0.9, 0.5, 1, 0, "
+                "'[]', ?, datetime('now'))",
+                (
+                    fact_id,
+                    f"m_{profile_id}",
+                    profile_id,
+                    fact_id,
+                    json.dumps([1.0, 0.0, 0.0, 0.0]),
+                ),
+            )
+    return EntityGraphChannel(db)
+
+
+class TestProfileLRU:
+    def test_interleaved_profiles_do_not_reload(self, tmp_path):
+        ch = _channel(tmp_path)
+        with patch.object(
+            EntityGraphChannel,
+            "_load_adjacency_from_db",
+            wraps=ch._load_adjacency_from_db,
+        ) as load:
+            ch._ensure_adjacency("a", include_global=False, include_shared=False)
+            ch._ensure_adjacency("b", include_global=False, include_shared=False)
+            ch._ensure_adjacency("a", include_global=False, include_shared=False)  # hot hit
+            ch._ensure_adjacency("b", include_global=False, include_shared=False)  # hot hit
+        assert load.call_count == 2  # single-slot implementation reloads 4 times here
+
+    def test_lru_eviction_reloads_evicted_profile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SLM_ADJ_CACHE_PROFILES", "2")
+        ch = _channel(tmp_path)
+        ch._ensure_adjacency("a", include_global=False, include_shared=False)
+        ch._ensure_adjacency("b", include_global=False, include_shared=False)
+        ch._ensure_adjacency("c", include_global=False, include_shared=False)  # evicts a
+        with patch.object(
+            EntityGraphChannel,
+            "_load_adjacency_from_db",
+            wraps=ch._load_adjacency_from_db,
+        ) as load:
+            ch._ensure_adjacency("a", include_global=False, include_shared=False)
+        assert load.call_count == 1  # a was evicted and must reload
+
+    def test_hot_hit_refreshes_the_compatibility_attributes(self, tmp_path):
+        """Zero-change contract: readers of the legacy single-slot attributes
+        (search(), score_candidates(), _resolve_entities()) must observe the
+        scope of the call they are serving, not whichever profile loaded last."""
+        ch = _channel(tmp_path)
+        ch._ensure_adjacency("a", include_global=False, include_shared=False)
+        ch._ensure_adjacency("b", include_global=False, include_shared=False)
+        assert ch._adj_profile == "b"
+        assert ch._visible_fact_ids == {"fact_b"}
+
+        ch._ensure_adjacency("a", include_global=False, include_shared=False)  # hot hit
+        assert ch._adj_profile == "a"
+        assert ch._adj_scope_key == ("a", False, False)
+        assert ch._visible_fact_ids == {"fact_a"}
+        assert ch._entity_to_facts == {}  # fact_a carries no entities
+        # "a" was re-entered last, so it is the most-recently-used slot.
+        assert list(ch._adj_slots)[-1] == ("a", False, False)

--- a/tests/test_server/test_per_request_profile.py
+++ b/tests/test_server/test_per_request_profile.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 Varun Pratap Bhardwaj / Qualixar
+# Licensed under AGPL-3.0-or-later
+
+"""Per-request profile routing at the daemon layer (spec section 3/5).
+
+A non-empty ``profile_id`` on POST /remember (body) and GET /recall (query)
+is pure routing: the request is served against THAT profile without touching
+the ProfileRuntime active pointer or its generation. An unknown profile is
+rejected with 404 + ``{"success": false, "error": {"code":
+"unknown_profile"}}`` and never implicitly created. An empty/absent
+profile_id keeps the legacy path byte-identical, including the stale-client
+guard slot, which is unreachable for routed requests.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from fastapi.testclient import TestClient
+
+from superlocalmemory.server.unified_daemon import create_app
+from superlocalmemory.storage.migrations import (
+    M018_ingestion_operations,
+    M032_write_coordinator_admission,
+    M033_projection_transactions,
+    M034_obligation_integrity,
+    M042_correction_case_ledger,
+)
+
+
+@contextmanager
+def _daemon(engine, profiles=("a", "b")):
+    """TestClient daemon with pre-created profiles, per tests/test_server convention.
+
+    Mirrors ``test_canonical_remember_route._client``: the daemon-owned
+    canonical writer is injected because TestClient does not enter lifespan.
+    """
+    from superlocalmemory.core.remember_runtime import CanonicalRememberRuntime
+
+    with engine._db.raw_connection() as conn:
+        M018_ingestion_operations.apply(conn)
+        M032_write_coordinator_admission.apply(conn)
+        M033_projection_transactions.apply(conn)
+        M034_obligation_integrity.apply(conn)
+        M042_correction_case_ledger.apply(conn)
+        for profile_id in profiles:
+            conn.execute(
+                "INSERT OR IGNORE INTO profiles (profile_id, name) "
+                "VALUES (?, ?)",
+                (profile_id, f"Profile {profile_id}"),
+            )
+        conn.commit()
+    app = create_app()
+    app.state.engine = engine
+    runtime = CanonicalRememberRuntime.for_engine(engine)
+    runtime.start()
+    app.state.canonical_remember_runtime = runtime
+    client = TestClient(app)
+    client.headers["X-SLM-Daemon-Capability"] = (
+        app.state.daemon_descriptor.capability
+    )
+    client.headers["X-SLM-Target-Instance"] = (
+        app.state.daemon_descriptor.instance_id
+    )
+    try:
+        yield client, app
+    finally:
+        runtime.stop()
+
+
+@pytest.fixture
+def daemon(engine_with_mock_deps):
+    with _daemon(engine_with_mock_deps) as pair:
+        yield pair
+
+
+def _facts_in(engine, profile_id: str, needle: str = "") -> list[str]:
+    rows = engine._db.execute(
+        "SELECT fact_id FROM atomic_facts WHERE profile_id = ? AND content LIKE ?",
+        (profile_id, f"%{needle}%"),
+    )
+    return [row["fact_id"] for row in rows]
+
+
+def _profile_row_count(engine) -> int:
+    rows = engine._db.execute("SELECT COUNT(*) AS c FROM profiles")
+    return int(dict(rows[0])["c"])
+
+
+class TestRouting:
+    def test_remember_routes_to_explicit_profile(self, daemon) -> None:
+        client, app = daemon
+        engine = app.state.engine
+        response = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Doris owns the release branch schedule and records "
+                    "every platform freeze window."
+                ),
+                "profile_id": "b",
+                "idempotency_key": "route-remember-b-1",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert _facts_in(engine, "b", "Doris"), (
+            "the routed fact must land in profile b"
+        )
+        assert _facts_in(engine, "a", "Doris") == []
+
+    def test_recall_routes_to_explicit_profile(self, daemon) -> None:
+        client, _ = daemon
+        client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Doris owns the release branch schedule and records "
+                    "every platform freeze window."
+                ),
+                "profile_id": "b",
+                "idempotency_key": "route-recall-b-1",
+            },
+        )
+        client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Zebra coordinates the zonal inventory audit and keeps "
+                    "the northern warehouse ledger."
+                ),
+                "profile_id": "a",
+                "idempotency_key": "route-recall-a-1",
+            },
+        )
+
+        hit = client.get(
+            "/recall", params={"q": "Doris release branch schedule", "profile_id": "b"},
+        )
+        assert hit.status_code == 200, hit.text
+        assert hit.json()["results"], "recall must hit the routed profile"
+
+        isolated = client.get(
+            "/recall", params={"q": "Doris release branch schedule", "profile_id": "a"},
+        )
+        assert isolated.status_code == 200, isolated.text
+        assert isolated.json()["results"] == []
+
+        reverse = client.get(
+            "/recall", params={"q": "Zebra inventory audit", "profile_id": "b"},
+        )
+        assert reverse.json()["results"] == []
+
+    def test_global_pointer_untouched(self, daemon) -> None:
+        client, _ = daemon
+        before = client.get("/status").json()
+        client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Quartz buffers the quarterly readiness review for the "
+                    "on-call rotation."
+                ),
+                "profile_id": "b",
+                "idempotency_key": "route-pointer-b-1",
+            },
+        )
+        client.get("/recall", params={"q": "Quartz readiness review", "profile_id": "b"})
+        after = client.get("/status").json()
+
+        assert after["profile"] == before["profile"]
+        assert after["profile_generation"] == before["profile_generation"]
+
+    def test_unknown_profile_rejected(self, daemon) -> None:
+        client, app = daemon
+        engine = app.state.engine
+        profiles_before = _profile_row_count(engine)
+
+        remembered = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Ghost owns no profile and must not be silently created."
+                ),
+                "profile_id": "ghost",
+                "idempotency_key": "route-unknown-1",
+            },
+        )
+        recalled = client.get(
+            "/recall", params={"q": "Ghost profile", "profile_id": "ghost"},
+        )
+
+        assert remembered.status_code == 404, remembered.text
+        body = remembered.json()
+        assert body["success"] is False
+        assert body["error"]["code"] == "unknown_profile"
+        assert body["error"]["profile_id"] == "ghost"
+
+        assert recalled.status_code == 404, recalled.text
+        recall_body = recalled.json()
+        assert recall_body["success"] is False
+        assert recall_body["error"]["code"] == "unknown_profile"
+
+        # No implicit creation, no engine touch.
+        assert _profile_row_count(engine) == profiles_before
+        assert engine._db.execute(
+            "SELECT COUNT(*) AS c FROM atomic_facts WHERE profile_id = 'ghost'"
+        )[0]["c"] == 0
+
+    def test_empty_profile_id_is_legacy_path(self, daemon) -> None:
+        client, app = daemon
+        engine = app.state.engine
+        active = client.get("/status").json()["profile"]
+
+        response = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Legacy writes keep landing in the active profile "
+                    "exactly as before."
+                ),
+                "idempotency_key": "route-legacy-1",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert _facts_in(engine, active, "Legacy writes"), (
+            "the legacy path must write to the active profile"
+        )
+        assert _facts_in(engine, "b", "Legacy writes") == []
+
+    def test_active_profile_explicit_is_not_error(self, daemon) -> None:
+        client, _ = daemon
+        active = client.get("/status").json()["profile"]
+
+        response = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Naming the active profile explicitly is routing, not "
+                    "a stale-client conflict."
+                ),
+                "profile_id": active,
+                "idempotency_key": "route-active-1",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["fact_ids"]

--- a/tests/test_server/test_per_request_profile.py
+++ b/tests/test_server/test_per_request_profile.py
@@ -15,6 +15,7 @@ guard slot, which is unreachable for routed requests.
 from __future__ import annotations
 
 from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -366,3 +367,213 @@ class TestRouting:
         ) == bound_limits
         assert runtime._routed_writers == {}
         assert runtime._generation == bound_generation
+
+
+# ---------------------------------------------------------------------------
+# Task 4: the MCP tool surface (spec section 4)
+#
+# remember/recall accept an optional ``profile_id`` and thread it to the
+# daemon's per-request routing (Task 3). Empty keeps the legacy call
+# byte-identical: the parameter must not appear in the daemon request at
+# all when it was not set, and it must be optional in the MCP schema.
+# ---------------------------------------------------------------------------
+
+class _ToolCaptureServer:
+    """Minimal @server.tool() capture, matching the tests/test_mcp convention."""
+
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self, *args, **kwargs):
+        def register(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+        return register
+
+
+def _core_tools() -> dict[str, object]:
+    from unittest.mock import MagicMock
+
+    from superlocalmemory.mcp.tools_core import register_core_tools
+
+    srv = _ToolCaptureServer()
+    register_core_tools(srv, MagicMock())
+    return srv.tools
+
+
+def _ok_pool() -> "MagicMock":
+    from unittest.mock import MagicMock
+
+    pool = MagicMock()
+    pool.store.return_value = {
+        "ok": True, "fact_ids": ["mcp-fact"], "count": 1,
+        "operation_id": "op-mcp", "pending_id": None,
+        "materialization_state": "complete",
+    }
+    pool.recall.return_value = {
+        "ok": True, "results": [{"fact_id": "mcp-fact", "content": "mcp fact",
+                                 "score": 0.9}],
+        "result_count": 1, "query_type": "sandbox",
+    }
+    return pool
+
+
+class TestMcpSurface:
+    def test_remember_tool_accepts_and_routes_profile_id(self, monkeypatch) -> None:
+        """remember(profile_id="b") puts the routing anchor in the daemon body."""
+        import asyncio
+
+        import superlocalmemory.cli.daemon as _d
+
+        captured: dict = {}
+
+        def _request(method, path, body=None, **kwargs):
+            captured.update(method=method, path=path, body=body)
+            return {"ok": True, "fact_ids": ["mcp-fact"], "count": 1,
+                    "status": "stored"}
+
+        monkeypatch.setattr(_d, "is_daemon_running", lambda *a, **k: True)
+        monkeypatch.setattr(_d, "daemon_request", _request)
+
+        remember = _core_tools()["remember"]
+        result = asyncio.run(remember("mcp fact", profile_id="b"))
+
+        assert result["success"] is True, result
+        assert captured["method"] == "POST"
+        assert captured["path"] == "/remember"
+        assert captured["body"]["profile_id"] == "b"
+
+    def test_remember_tool_offline_fallback_threads_profile_id(
+        self, monkeypatch,
+    ) -> None:
+        """The pool.store fallback carries the anchor in worker metadata."""
+        import asyncio
+
+        import superlocalmemory.cli.daemon as _d
+
+        monkeypatch.setattr(_d, "is_daemon_running", lambda *a, **k: False)
+        pool = _ok_pool()
+
+        remember = _core_tools()["remember"]
+        with patch(
+            "superlocalmemory.mcp._daemon_proxy.choose_pool", return_value=pool,
+        ):
+            result = asyncio.run(remember("mcp fact", profile_id="b"))
+
+        assert result["success"] is True, result
+        pool.store.assert_called_once()
+        assert pool.store.call_args.args[1]["profile_id"] == "b"
+
+    def test_remember_tool_legacy_call_has_no_profile_anchor(
+        self, monkeypatch,
+    ) -> None:
+        """No profile_id → the daemon body is the legacy shape, key absent."""
+        import asyncio
+
+        import superlocalmemory.cli.daemon as _d
+
+        captured: dict = {}
+
+        def _request(method, path, body=None, **kwargs):
+            captured.update(method=method, path=path, body=body)
+            return {"ok": True, "fact_ids": ["mcp-fact"], "count": 1,
+                    "status": "stored"}
+
+        monkeypatch.setattr(_d, "is_daemon_running", lambda *a, **k: True)
+        monkeypatch.setattr(_d, "daemon_request", _request)
+
+        remember = _core_tools()["remember"]
+        result = asyncio.run(remember("mcp fact"))
+
+        assert result["success"] is True, result
+        assert "profile_id" not in captured["body"]
+
+    def test_recall_tool_accepts_and_routes_profile_id(self, monkeypatch) -> None:
+        """recall(profile_id="b") threads the anchor to pool.recall."""
+        import asyncio
+
+        import superlocalmemory.cli.daemon as _d
+
+        monkeypatch.setattr(_d, "is_daemon_running", lambda *a, **k: False)
+        pool = _ok_pool()
+
+        recall = _core_tools()["recall"]
+        with patch(
+            "superlocalmemory.mcp._daemon_proxy.choose_pool", return_value=pool,
+        ):
+            result = asyncio.run(recall("mcp fact", profile_id="b"))
+
+        assert result["success"] is True, result
+        assert result["results"], "recall must surface the sandbox hit"
+        assert pool.recall.call_args.kwargs["profile_id"] == "b"
+
+    def test_recall_tool_legacy_call_has_no_profile_anchor(
+        self, monkeypatch,
+    ) -> None:
+        """No profile_id → pool.recall is called without the parameter."""
+        import asyncio
+
+        import superlocalmemory.cli.daemon as _d
+
+        monkeypatch.setattr(_d, "is_daemon_running", lambda *a, **k: False)
+        pool = _ok_pool()
+
+        recall = _core_tools()["recall"]
+        with patch(
+            "superlocalmemory.mcp._daemon_proxy.choose_pool", return_value=pool,
+        ):
+            result = asyncio.run(recall("mcp fact"))
+
+        assert result["success"] is True, result
+        assert "profile_id" not in pool.recall.call_args.kwargs
+
+    def test_daemon_pool_proxy_recall_sends_profile_id_param(
+        self, monkeypatch,
+    ) -> None:
+        """DaemonPoolProxy serializes the anchor into the GET /recall query.
+
+        This is the brief's "verify the proxy passes it through" check made
+        executable: without the parameter the MCP tool's recall cannot reach
+        the daemon's per-request routing at all.
+        """
+        from superlocalmemory.mcp._daemon_proxy import DaemonPoolProxy
+
+        captured: dict = {}
+
+        def _request(method, path, body=None, **kwargs):
+            captured.update(method=method, path=path)
+            return {"ok": True, "results": [], "query_type": "sandbox"}
+
+        monkeypatch.setattr(
+            "superlocalmemory.cli.daemon.daemon_request", _request,
+        )
+
+        proxy = DaemonPoolProxy(port=9999)
+        assert proxy.recall("mcp fact", profile_id="b")["ok"] is True
+        assert captured["method"] == "GET"
+        assert "profile_id=b" in captured["path"]
+
+        # Legacy shape: unset anchor never appears on the wire.
+        assert proxy.recall("mcp fact")["ok"] is True
+        assert "profile_id=" not in captured["path"]
+
+    def test_tool_schema_allows_new_optional_param(self) -> None:
+        """The schema layer exposes profile_id as optional on both tools."""
+        from unittest.mock import MagicMock
+
+        from superlocalmemory.mcp.http_transport import SLMFastMCP
+        from superlocalmemory.mcp.tools_core import register_core_tools
+
+        srv = SLMFastMCP("schema probe")
+        register_core_tools(srv, MagicMock())
+        tools = {t.name: t for t in srv._tool_manager.list_tools()}
+
+        for name in ("remember", "recall"):
+            schema = tools[name].parameters
+            assert "profile_id" in schema["properties"], (
+                f"{name} must expose profile_id"
+            )
+            required = schema.get("required", [])
+            assert required.count("profile_id") == 0, (
+                f"{name}.profile_id must be optional"
+            )

--- a/tests/test_server/test_per_request_profile.py
+++ b/tests/test_server/test_per_request_profile.py
@@ -577,3 +577,176 @@ class TestMcpSurface:
             assert required.count("profile_id") == 0, (
                 f"{name}.profile_id must be optional"
             )
+
+
+# ---------------------------------------------------------------------------
+# Final-review I-1: routed writes get inline enrichment against THEIR profile
+#
+# The daemon's post-write enrichment used the engine's ACTIVE profile for its
+# tenant-scoped lookups, so a routed write's fact_ids resolved to None: every
+# routed response said searchable_by="wording" no matter what the embedder
+# could have done. The write target must be threaded through
+# _enrich_and_release → engine.enrich_new_facts_now.
+# ---------------------------------------------------------------------------
+
+class TestRoutedInlineEnrichment:
+    @staticmethod
+    def _spy_enrich(engine, monkeypatch):
+        """Capture how the daemon calls engine.enrich_new_facts_now."""
+        import superlocalmemory.core.engine as _engine_mod
+
+        real = _engine_mod.MemoryEngine.enrich_new_facts_now
+        captured: dict = {}
+
+        def _spy(fact_ids, **kwargs):
+            captured["fact_ids"] = list(fact_ids)
+            captured["kwargs"] = kwargs
+            # Set on the instance, so no implicit self arrives here.
+            return real(engine, fact_ids, **kwargs)
+
+        monkeypatch.setattr(engine, "enrich_new_facts_now", _spy)
+        return captured
+
+    @staticmethod
+    def _warm_mock_embedder(engine, monkeypatch):
+        """Let the mocked-deps engine actually embed inline.
+
+        The fixture's mock embedder reads cold-and-remote, so the warm guard
+        declines by design; patching the guard is the sanctioned seam that
+        makes an enriched>0 outcome observable (same helper as the engine
+        test file).
+        """
+        monkeypatch.setattr(
+            engine, "_warm_guard_embed",
+            lambda text, *, timeout_s=None: ([0.01] * 768, [0.0] * 768, [1.0] * 768),
+        )
+
+    def test_routed_remember_enriches_against_the_routed_profile(
+        self, daemon, monkeypatch,
+    ) -> None:
+        client, app = daemon
+        engine = app.state.engine
+        active = client.get("/status").json()["profile"]
+        assert active != "b"
+        self._warm_mock_embedder(engine, monkeypatch)
+        captured = self._spy_enrich(engine, monkeypatch)
+
+        response = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Routed Rowan keeps the relay baton rota for the night "
+                    "shift and files the handover notes."
+                ),
+                "profile_id": "b",
+                "idempotency_key": "route-enrich-b-1",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["profile"] == "b"
+        assert body["fact_ids"]
+
+        # The daemon threaded the write target into the enrichment call —
+        # before the fix this was always the active profile and the routed
+        # facts resolved to None inside the tenant-scoped lookup.
+        assert captured["kwargs"].get("profile_id") == "b", captured
+        assert captured["fact_ids"] == body["fact_ids"]
+
+        # And the routed rows were genuinely enriched: the receipt reports
+        # meaning-searchable instead of the permanent "wording" the routed
+        # path used to return.
+        assert body["enriched_now"] == body["count"], body
+        assert body["searchable_by"] == "meaning", body
+
+    def test_legacy_remember_enrichment_uses_the_active_profile(
+        self, daemon, monkeypatch,
+    ) -> None:
+        client, app = daemon
+        engine = app.state.engine
+        active = client.get("/status").json()["profile"]
+        self._warm_mock_embedder(engine, monkeypatch)
+        captured = self._spy_enrich(engine, monkeypatch)
+
+        response = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Legacy Lachlan enriches exactly as before the feature, "
+                    "against the active profile."
+                ),
+                "idempotency_key": "route-enrich-legacy-1",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["profile"] == active
+        assert captured["kwargs"].get("profile_id") == active, captured
+        assert body["enriched_now"] == body["count"], body
+        assert body["searchable_by"] == "meaning", body
+
+    def test_routed_requests_leave_one_routing_log_line(
+        self, daemon, caplog,
+    ) -> None:
+        """M-2: routed requests are distinguishable in the daemon log.
+
+        One info line per routed request (method, path, profile), nothing on
+        the legacy path — the routing is otherwise invisible: the response
+        envelope names the profile, but the global pointer never moves.
+        """
+        import logging
+
+        client, _ = daemon
+        # The daemon module names its logger without the ".server." segment.
+        with caplog.at_level(
+            logging.INFO, logger="superlocalmemory.unified_daemon",
+        ):
+            routed_write = client.post(
+                "/remember",
+                json={
+                    "content": (
+                        "LogLine Lyra proves routed writes are visible in "
+                        "the daemon log."
+                    ),
+                    "profile_id": "b",
+                    "idempotency_key": "route-logline-b-1",
+                },
+            )
+            routed_read = client.get(
+                "/recall", params={"q": "LogLine Lyra", "profile_id": "b"},
+            )
+            legacy_write = client.post(
+                "/remember",
+                json={
+                    "content": (
+                        "LogLine Lena stays silent on the legacy path."
+                    ),
+                    "idempotency_key": "route-logline-legacy-1",
+                },
+            )
+            legacy_read = client.get(
+                "/recall", params={"q": "LogLine Lena"},
+            )
+
+        assert routed_write.status_code == 200, routed_write.text
+        assert routed_read.status_code == 200, routed_read.text
+        assert legacy_write.status_code == 200, legacy_write.text
+        assert legacy_read.status_code == 200, legacy_read.text
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(
+            "per-request profile routing: POST /remember profile=b" in m
+            for m in messages
+        ), f"no routed-write log line in {messages}"
+        assert any(
+            "per-request profile routing: GET /recall profile=b" in m
+            for m in messages
+        ), f"no routed-read log line in {messages}"
+        # Legacy requests stay silent: exactly two routing lines, both for b.
+        routing_lines = [
+            m for m in messages if "per-request profile routing" in m
+        ]
+        assert len(routing_lines) == 2, routing_lines
+        assert all(m.endswith("profile=b") for m in routing_lines), routing_lines

--- a/tests/test_server/test_per_request_profile.py
+++ b/tests/test_server/test_per_request_profile.py
@@ -155,7 +155,7 @@ class TestRouting:
     def test_global_pointer_untouched(self, daemon) -> None:
         client, _ = daemon
         before = client.get("/status").json()
-        client.post(
+        write = client.post(
             "/remember",
             json={
                 "content": (
@@ -166,9 +166,15 @@ class TestRouting:
                 "idempotency_key": "route-pointer-b-1",
             },
         )
-        client.get("/recall", params={"q": "Quartz readiness review", "profile_id": "b"})
+        lookup = client.get(
+            "/recall", params={"q": "Quartz readiness review", "profile_id": "b"},
+        )
         after = client.get("/status").json()
 
+        # The routed calls must have actually succeeded, or the pointer
+        # comparison below would pass vacuously.
+        assert write.status_code == 200, write.text
+        assert lookup.status_code == 200, lookup.text
         assert after["profile"] == before["profile"]
         assert after["profile_generation"] == before["profile_generation"]
 
@@ -248,3 +254,115 @@ class TestRouting:
 
         assert response.status_code == 200, response.text
         assert response.json()["fact_ids"]
+
+    def test_routed_responses_report_the_routed_profile(self, daemon) -> None:
+        """The success envelopes echo the profile that served the request.
+
+        A routed b-profile answer reporting ``"profile": "default"`` (the
+        active snapshot) would tell the caller their memory came from a
+        profile that never saw it. profile_generation stays from the
+        snapshot: it describes global switch state, which per-request
+        routing never moves.
+        """
+        client, _ = daemon
+        status = client.get("/status").json()
+        active = status["profile"]
+
+        remembered = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Hazel tracks the harbor crane maintenance windows for "
+                    "the coastal crew."
+                ),
+                "profile_id": "b",
+                "idempotency_key": "route-echo-b-1",
+            },
+        )
+        assert remembered.status_code == 200, remembered.text
+        assert remembered.json()["profile"] == "b"
+
+        recalled = client.get(
+            "/recall",
+            params={"q": "Hazel crane maintenance", "profile_id": "b"},
+        )
+        assert recalled.status_code == 200, recalled.text
+        assert recalled.json()["profile"] == "b"
+        assert recalled.json()["profile_generation"] == status["profile_generation"]
+
+        legacy = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Ivory keeps the inland depot roster on the legacy path."
+                ),
+                "idempotency_key": "route-echo-legacy-1",
+            },
+        )
+        assert legacy.status_code == 200, legacy.text
+        assert legacy.json()["profile"] == active
+
+        legacy_recall = client.get(
+            "/recall", params={"q": "Ivory depot roster"},
+        )
+        assert legacy_recall.status_code == 200, legacy_recall.text
+        assert legacy_recall.json()["profile"] == active
+
+    def test_failed_rebind_rolls_back_routed_writers_and_limits(
+        self, daemon, monkeypatch,
+    ) -> None:
+        """A failed rebind restores the whole binding, not just the writer.
+
+        The routed-handler cache and the writer limits swapped in before
+        replay_pending() must not outlive a rebind that never completed.
+        """
+        from types import SimpleNamespace
+
+        client, app = daemon
+        engine = app.state.engine
+        runtime = app.state.canonical_remember_runtime
+
+        warmed = client.post(
+            "/remember",
+            json={
+                "content": (
+                    "Juniper anchors the joint readiness ledger before the "
+                    "rebind attempt."
+                ),
+                "profile_id": "b",
+                "idempotency_key": "route-rebind-warm-1",
+            },
+        )
+        assert warmed.status_code == 200, warmed.text
+        assert "b" in runtime._routed_writers, (
+            "a routed write must have cached a handler for profile b"
+        )
+        bound_profile = runtime._profile_id
+        bound_limits = (
+            runtime._max_verbatim_chars, runtime._max_ingest_bytes,
+        )
+        bound_generation = runtime._generation
+
+        def _fail_replay():
+            raise RuntimeError("replay failed after rebind")
+
+        monkeypatch.setattr(runtime, "replay_pending", _fail_replay)
+        rebinding = SimpleNamespace(
+            _db=engine._db,
+            _profile_id="a",
+            _config=SimpleNamespace(
+                store=SimpleNamespace(
+                    max_verbatim_chars=99, max_ingest_bytes=99,
+                ),
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="replay failed"):
+            runtime.rebind_engine(rebinding)
+
+        assert runtime._profile_id == bound_profile
+        assert (
+            runtime._max_verbatim_chars, runtime._max_ingest_bytes,
+        ) == bound_limits
+        assert runtime._routed_writers == {}
+        assert runtime._generation == bound_generation


### PR DESCRIPTION
## Problem

The daemon's active profile is a single machine-wide pointer. With two clients on one data root (e.g. `zhihui` + `doris`), whichever client last called `switch_profile` silently redirects the other's unscoped reads/writes — no concurrency required, sequential alternation triggers it.

We shipped this exact bug in production: a client running `profile=zhihui` was silently writing into `doris` (3 facts) for a full session after the other client switched. The other client's 11,635 facts were unreachable to it.

## Approach: per-request profile_id (routing replaces refusal)

Engine layer (`engine.recall` already has `profile_id`; this completes `store`/`store_fact_direct`/`store_fast`):

    pid = profile_id or self._profile_id   # same convention as recall

Daemon layer (`/remember`, `/recall`): a non-empty `profile_id` routes the request to that profile **without** reading or mutating the global active pointer or `profile_generation`. An unknown profile gets `404 + {"success": false, "error": {"code": "unknown_profile"}}` — never implicit creation.

MCP layer: `remember`/`recall` tools gain the optional param; FastMCP auto-generates the schema; `SLM_MCP_TOOLS` allowlist (tool names) unchanged.

Retrieval: the adjacency cache becomes a profile-keyed LRU (default 3 slots, `SLM_ADJ_CACHE_PROFILES`) — two interleaved profiles no longer thrash a full reload every call.

## The 409 guard is superseded, not removed

4.1.x added `RememberRequest.profile_id` as a compare-and-write 409 guard ("the daemon remains single-profile, so a stale MCP client must fail"). This PR makes routing correct for non-empty `profile_id`, so the guard's mission is accomplished by *routing* — a stale client now writes correctly instead of failing. The guard code stays for the empty/whitespace legacy shape (byte-identical to before).

## Evidence

- Full suite 11095 passed / 0 failed (2:47:51); hermes provider 118/118
- Real-daemon e2e (`tests/test_integration/test_per_request_profile_e2e.py`): two clients interleaved remember/recall with frozen pointer, 50×2 concurrent writes counted by profile (zero crossover, total exactly 100), MCP stdio child with `SLM_MCP_TOOLS=remember,recall` carrying the param end-to-end
- The production incident that motivated this is documented and reproduced
- Includes the inline-enrichment fix (routed writes enrich against THEIR profile, not the active one) — caught by a routed-vs-legacy probe during review

## What is NOT in this PR

- No new daemon endpoints, no per-profile engine pools, no profile-level ACL (out of scope, spec notes it as future work)
- The hermes provider pin (fork-only; lives in our tree)
- `get_status` per-profile stats (spec marks it non-essential)

## Notes for review

- The two deferred minors are the residual: /recall's empty-query early-return and keyword-fallback bodies don't carry the new `profile` echo (only the full success path does), and routed writes rely on the background materializer for vector enrichment when the inline budget is exceeded — both documented in the spec.
- `SLM_ADJ_CACHE_PROFILES` default 3 is a rough heuristic (typical deployments: 2 active profiles + 1 headroom).